### PR TITLE
test: cover plugins by tests

### DIFF
--- a/src/main/compat/core.js
+++ b/src/main/compat/core.js
@@ -4,8 +4,27 @@ import {
   Fragment as _Fragment,
   memo as _memo,
 } from '@simpreact/core';
-import { isFragment, isPortal } from '@simpreact/internal';
+import { isFragment, isPortal, withSyncRerender } from '@simpreact/internal';
 import { useCatch, useState } from './hooks.js';
+import { renderRuntime } from './renderRuntime.js';
+
+// Threads refs through FC elements without polluting string-keyed props.
+// Symbol keys are invisible to `for…in` and Object.keys, so they never
+// accidentally end up on HOST elements via `{...props}` spread.
+export const REF_SYMBOL = Symbol('simpreact.compat.ref');
+
+// Wraps core createElement to strip `ref` from FC props (matching React's
+// model where ref is not part of the props the component receives).
+export function createElement(type, props, ...args) {
+  if (typeof type === 'function' && props != null && 'ref' in props) {
+    const { ref, ...restProps } = props;
+    if (ref != null) {
+      restProps[REF_SYMBOL] = ref;
+    }
+    return _createElement(type, restProps, ...args);
+  }
+  return _createElement(type, props, ...args);
+}
 
 export const Children = {
   map(children, fn) {
@@ -59,11 +78,12 @@ export function cloneElement(element, props, ...children) {
     throw new Error('cloneElement: the argument must be a SimpElement, but you passed a portal instead.');
   }
 
-  return createElement(
-    isFragment(element) ? Fragment : element.type,
-    Object.assign({}, element.props, props),
-    arguments.length > 2 ? children : props.children || element.children
-  );
+  const mergedProps = Object.assign({}, element.props, props);
+
+  const resolvedChildren =
+    arguments.length > 2 ? children : mergedProps.children !== undefined ? mergedProps.children : element.children;
+
+  return createElement(isFragment(element) ? Fragment : element.type, mergedProps, resolvedChildren);
 }
 
 export function isValidElement(element) {
@@ -71,41 +91,49 @@ export function isValidElement(element) {
 }
 
 export function Suspense(props) {
-  const [isSuspended, setIsSuspended] = useState(false);
+  const [pendingCount, setPendingCount] = useState(0);
 
   useCatch(error => {
     if (!(error instanceof Promise)) {
       throw error;
     }
-
-    if (isSuspended) {
-      return;
-    }
-
-    setIsSuspended(true);
-    error.then(() => setIsSuspended(false));
+    setPendingCount(c => c + 1);
+    error.then(() => setPendingCount(c => c - 1));
   });
 
-  return isSuspended ? props.fallback : props.children;
+  return pendingCount > 0 ? props.fallback : props.children;
 }
 
 export function StrictMode(props) {
   return props.children;
 }
 
+// Reads the ref from the Symbol slot so that string-keyed `ref` never
+// appears in the props the inner component receives.
 export function forwardRef(Component) {
   return function Forwarded(props) {
-    return Component(props, props?.ref ?? null);
+    const ref = props?.[REF_SYMBOL] ?? null;
+    if (props != null && REF_SYMBOL in props) {
+      const { [REF_SYMBOL]: _, ...restProps } = props;
+      return Component(restProps, ref);
+    }
+    return Component(props, ref);
   };
 }
 
 export const version = '18.3.1';
 
 export const Fragment = _Fragment;
-export const createElement = _createElement;
 export const createPortal = _createPortal;
 export const memo = _memo;
-export const flushSync = callback => callback();
+
+export function flushSync(callback) {
+  let result;
+  withSyncRerender(renderRuntime, () => {
+    result = callback();
+  });
+  return result;
+}
 
 export function lazy(factory) {
   let state = null;
@@ -132,11 +160,25 @@ export function lazy(factory) {
   };
 }
 
+// Minimal base class for React-style class components.
+// setState and forceUpdate are no-ops here; the compat renderer overrides
+// them on each instance with real implementations backed by the render queue.
 export class Component {
-  constructor() {
-    throw new Error('Not implemented.');
+  constructor(props) {
+    this.props = props;
+    this.state = {};
+  }
+
+  setState(_updater, _callback) {}
+
+  forceUpdate(_callback) {}
+
+  render() {
+    throw new Error('Component.render() must be implemented by the subclass.');
   }
 }
+
+Component.prototype.isReactComponent = true;
 
 export default {
   version,

--- a/src/main/compat/renderRuntime.js
+++ b/src/main/compat/renderRuntime.js
@@ -1,16 +1,55 @@
 import { domAdapter } from '@simpreact/dom';
+import { createUseRef, createUseRerender } from '@simpreact/hooks';
 import { createRenderRuntime } from '@simpreact/internal';
 import { emptyObject } from '@simpreact/shared';
+
+// Lazily assigned after renderRuntime is created to avoid a circular reference
+// at module-evaluation time. Both are set before any render can fire.
+let useRef;
+let useRerender;
 
 export const renderRuntime = createRenderRuntime(domAdapter, function renderer(component, element) {
   const props = element.props || emptyObject;
   const proto = component.prototype;
+
   if (proto?.isReactComponent || proto?.render) {
-    const inst = new component(props);
+    // Persist the instance across re-renders so state is not reset on every
+    // render cycle. Both hook calls run in the current FC render context.
+    const instRef = useRef(null);
+    const rerender = useRerender();
+
+    if (instRef.current === null) {
+      instRef.current = new component(props);
+      if (instRef.current.state == null) {
+        instRef.current.state = {};
+      }
+    }
+
+    const inst = instRef.current;
+    inst.props = props;
+
+    // Override the no-op stubs from Component base with real implementations.
+    inst.setState = function (updater, callback) {
+      const prevState = inst.state;
+      const patch = typeof updater === 'function' ? updater(prevState, inst.props) : updater;
+      inst.state = Object.assign({}, prevState, patch);
+      rerender();
+      callback?.();
+    };
+
+    inst.forceUpdate = function (callback) {
+      rerender();
+      callback?.();
+    };
+
     return inst.render();
   }
+
   return component(props);
 });
+
+useRef = createUseRef(renderRuntime);
+useRerender = createUseRerender(renderRuntime);
 
 export default {
   renderRuntime,

--- a/src/test/compat/core.test.js
+++ b/src/test/compat/core.test.js
@@ -1,0 +1,562 @@
+import { withSyncRerender } from '@simpreact/internal';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Children,
+  Component,
+  cloneElement,
+  createElement,
+  createPortal,
+  Fragment,
+  flushSync,
+  forwardRef,
+  isValidElement,
+  lazy,
+  REF_SYMBOL,
+  StrictMode,
+  Suspense,
+} from '../../main/compat/core.js';
+import { render } from '../../main/compat/dom.js';
+import { useState } from '../../main/compat/hooks.js';
+import { renderRuntime } from '../../main/compat/index.js';
+
+const flushMicrotasks = () => new Promise(r => setTimeout(r, 0));
+
+describe('isValidElement', () => {
+  it('returns true for a createElement result', () => {
+    expect(isValidElement(createElement('div'))).toBe(true);
+  });
+
+  it('returns false for a plain string', () => {
+    expect(isValidElement('hello')).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isValidElement(null)).toBe(false);
+  });
+
+  it('returns false for a plain object without flag', () => {
+    expect(isValidElement({ type: 'div', props: {} })).toBe(false);
+  });
+
+  it('returns true for a Fragment element', () => {
+    expect(isValidElement(createElement(Fragment))).toBe(true);
+  });
+});
+
+describe('Children', () => {
+  describe('toArray', () => {
+    it('returns empty array for null', () => {
+      expect(Children.toArray(null)).toEqual([]);
+    });
+
+    it('returns empty array for undefined', () => {
+      expect(Children.toArray(undefined)).toEqual([]);
+    });
+
+    it('returns empty array for true', () => {
+      expect(Children.toArray(true)).toEqual([]);
+    });
+
+    it('returns empty array for false', () => {
+      expect(Children.toArray(false)).toEqual([]);
+    });
+
+    it('flattens a nested array', () => {
+      const a = createElement('span');
+      const b = createElement('div');
+      expect(Children.toArray([[a], [b]])).toEqual([a, b]);
+    });
+
+    it('wraps a single element in an array', () => {
+      const el = createElement('p');
+      expect(Children.toArray(el)).toEqual([el]);
+    });
+
+    it('preserves strings and numbers', () => {
+      expect(Children.toArray(['text', 42])).toEqual(['text', 42]);
+    });
+
+    it('filters out null and boolean from mixed arrays', () => {
+      const el = createElement('div');
+      expect(Children.toArray([null, true, el, false, undefined])).toEqual([el]);
+    });
+  });
+
+  describe('map', () => {
+    it('maps over children applying the function', () => {
+      const result = Children.map(['a', 'b', 'c'], c => `${c}!`);
+      expect(result).toEqual(['a!', 'b!', 'c!']);
+    });
+  });
+
+  describe('forEach', () => {
+    it('iterates over children without returning a value', () => {
+      const seen = [];
+      const result = Children.forEach(['x', 'y'], c => seen.push(c));
+      expect(seen).toEqual(['x', 'y']);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('count', () => {
+    it('counts the number of children', () => {
+      expect(Children.count([createElement('a'), createElement('b')])).toBe(2);
+    });
+
+    it('returns 0 for null', () => {
+      expect(Children.count(null)).toBe(0);
+    });
+  });
+
+  describe('only', () => {
+    it('returns the single child element', () => {
+      const el = createElement('div');
+      expect(Children.only(el)).toBe(el);
+    });
+
+    it('throws when there are multiple children', () => {
+      expect(() => Children.only([createElement('a'), createElement('b')])).toThrow(
+        'Children.only expected a single SimpElement child.'
+      );
+    });
+
+    it('throws when the child is not a valid element', () => {
+      expect(() => Children.only('text')).toThrow('Children.only expected a single SimpElement child.');
+    });
+  });
+});
+
+describe('cloneElement', () => {
+  it('throws when argument is not a valid element', () => {
+    expect(() => cloneElement('not-an-element', {})).toThrow('cloneElement: expected a SimpElement');
+  });
+
+  it('throws when argument is a portal', () => {
+    const portal = createPortal(createElement('div'), document.createElement('div'));
+    expect(() => cloneElement(portal, {})).toThrow('cloneElement: the argument must be a SimpElement');
+  });
+
+  it('merges new props over existing element props', () => {
+    const el = createElement('div', { id: 'old', className: 'x' });
+    const cloned = cloneElement(el, { id: 'new' });
+    expect(cloned.props).toMatchObject({ id: 'new', className: 'x' });
+  });
+
+  it('uses varargs children when passed as extra arguments', () => {
+    const el = createElement('div', null, createElement('span'));
+    const child = createElement('p');
+    const cloned = cloneElement(el, {}, child);
+    expect(cloned.children).toBeDefined();
+  });
+
+  it('falls back to element.children when no children provided and props.children is undefined', () => {
+    const inner = createElement('span', null, 'hello');
+    const el = createElement('div', null, inner);
+    const cloned = cloneElement(el, { id: 'test' });
+    expect(cloned.children).toBeDefined();
+  });
+
+  it('respects falsy props.children (empty string) instead of falling back to element.children', () => {
+    const el = createElement('div', null, createElement('span', null, 'original'));
+    const cloned = cloneElement(el, { children: '' });
+    // Empty string is a valid children value; should NOT fall back to element.children
+    expect(cloned.children).toBeNull();
+  });
+
+  it('clones a Fragment element', () => {
+    const el = createElement(Fragment, null, createElement('span'));
+    const cloned = cloneElement(el, {});
+    expect(isValidElement(cloned)).toBe(true);
+  });
+});
+
+describe('StrictMode', () => {
+  it('returns its children prop unchanged', () => {
+    const child = createElement('div');
+    expect(StrictMode({ children: child })).toBe(child);
+  });
+});
+
+describe('flushSync', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('calls the callback synchronously and returns its result', () => {
+    const result = flushSync(() => 42);
+    expect(result).toBe(42);
+  });
+
+  it('flushes pending state updates synchronously so the DOM reflects the new state before returning', () => {
+    let setState;
+    const Comp = () => {
+      const [count, set] = useState(0);
+      setState = set;
+      return createElement('span', null, String(count));
+    };
+    render(createElement(Comp, {}), container);
+    expect(container.textContent).toBe('0');
+
+    flushSync(() => setState(1));
+    expect(container.textContent).toBe('1');
+  });
+});
+
+describe('createElement (compat wrapper)', () => {
+  it('strips string ref from FC props and stores under REF_SYMBOL', () => {
+    const myRef = { current: null };
+    const FC = () => createElement('div');
+    const el = createElement(FC, { ref: myRef, label: 'hi' });
+    expect(el.props.ref).toBeUndefined();
+    expect(el.props[REF_SYMBOL]).toBe(myRef);
+    expect(el.props.label).toBe('hi');
+  });
+
+  it('does not strip ref from HOST element props', () => {
+    const myRef = { current: null };
+    const el = createElement('div', { ref: myRef, id: 'x' });
+    expect(el.props.ref).toBe(myRef);
+  });
+
+  it('omits REF_SYMBOL when ref is null', () => {
+    const FC = () => createElement('div');
+    const el = createElement(FC, { ref: null, label: 'hi' });
+    expect(REF_SYMBOL in (el.props || {})).toBe(false);
+  });
+});
+
+describe('forwardRef', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('passes the ref as the second argument to the wrapped component', () => {
+    const receivedRefs = [];
+    const Inner = (props, ref) => {
+      receivedRefs.push(ref);
+      return createElement('div');
+    };
+    const Forwarded = forwardRef(Inner);
+    const myRef = { current: null };
+    render(createElement(Forwarded, { ref: myRef, label: 'hi' }), container);
+    expect(receivedRefs[0]).toBe(myRef);
+  });
+
+  it('strips ref from the props the inner component receives', () => {
+    const receivedProps = [];
+    const Inner = (props, _ref) => {
+      receivedProps.push(props);
+      return createElement('div');
+    };
+    const Forwarded = forwardRef(Inner);
+    const myRef = { current: null };
+    render(createElement(Forwarded, { ref: myRef, name: 'test' }), container);
+    expect('ref' in receivedProps[0]).toBe(false);
+    expect(receivedProps[0].name).toBe('test');
+  });
+
+  it('passes null when no ref is provided', () => {
+    const receivedRefs = [];
+    const Inner = (_props, ref) => {
+      receivedRefs.push(ref);
+      return createElement('div');
+    };
+    const Forwarded = forwardRef(Inner);
+    render(createElement(Forwarded, { label: 'hi' }), container);
+    expect(receivedRefs[0]).toBeNull();
+  });
+
+  it('works end-to-end: ref is attached to the inner HOST element', () => {
+    const ref = { current: null };
+    const Input = forwardRef((_props, ref) => createElement('input', { ref }));
+    render(createElement(Input, { ref }), container);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+});
+
+describe('Component', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('can be instantiated and initialises props and state', () => {
+    const inst = new Component({ name: 'test' });
+    expect(inst.props).toEqual({ name: 'test' });
+    expect(inst.state).toEqual({});
+  });
+
+  it('render() throws when not overridden', () => {
+    const inst = new Component({});
+    expect(() => inst.render()).toThrow('Component.render() must be implemented');
+  });
+
+  it('has isReactComponent on the prototype (used for duck-type detection)', () => {
+    expect(Component.prototype.isReactComponent).toBe(true);
+  });
+
+  it('subclass can override render() and mount successfully', () => {
+    class Greeting extends Component {
+      render() {
+        return createElement('span', null, this.props.name);
+      }
+    }
+    render(createElement(Greeting, { name: 'World' }), container);
+    expect(container.textContent).toBe('World');
+  });
+
+  it('setState updates state and triggers a re-render', () => {
+    let capturedInst;
+    class Counter extends Component {
+      constructor(props) {
+        super(props);
+        this.state = { count: 0 };
+        capturedInst = this;
+      }
+      render() {
+        return createElement('span', null, String(this.state.count));
+      }
+    }
+    render(createElement(Counter, {}), container);
+    expect(container.textContent).toBe('0');
+
+    withSyncRerender(renderRuntime, () => capturedInst.setState({ count: 5 }));
+    expect(container.textContent).toBe('5');
+  });
+
+  it('setState with an updater function receives previous state', () => {
+    let capturedInst;
+    class Counter extends Component {
+      constructor(props) {
+        super(props);
+        this.state = { count: 10 };
+        capturedInst = this;
+      }
+      render() {
+        return createElement('span', null, String(this.state.count));
+      }
+    }
+    render(createElement(Counter, {}), container);
+
+    withSyncRerender(renderRuntime, () => capturedInst.setState(prev => ({ count: prev.count + 3 })));
+    expect(container.textContent).toBe('13');
+  });
+
+  it('forceUpdate triggers a re-render without changing state', () => {
+    let capturedInst;
+    let renderCount = 0;
+    class Watched extends Component {
+      constructor(props) {
+        super(props);
+        capturedInst = this;
+      }
+      render() {
+        renderCount++;
+        return createElement('div');
+      }
+    }
+    render(createElement(Watched, {}), container);
+    expect(renderCount).toBe(1);
+
+    withSyncRerender(renderRuntime, () => capturedInst.forceUpdate());
+    expect(renderCount).toBe(2);
+  });
+
+  it('re-renders receive updated props', () => {
+    class ShowProp extends Component {
+      render() {
+        return createElement('span', null, this.props.value);
+      }
+    }
+    render(createElement(ShowProp, { value: 'a' }), container);
+    expect(container.textContent).toBe('a');
+    render(createElement(ShowProp, { value: 'b' }), container);
+    expect(container.textContent).toBe('b');
+  });
+});
+
+describe('lazy', () => {
+  it('throws the pending promise on first call', () => {
+    const factory = vi.fn(() => new Promise(() => {}));
+    const LazyComponent = lazy(factory);
+
+    let thrown;
+    try {
+      LazyComponent({});
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(Promise);
+  });
+
+  it('factory is called exactly once across multiple pending calls', () => {
+    const factory = vi.fn(() => new Promise(() => {}));
+    const LazyComponent = lazy(factory);
+
+    try {
+      LazyComponent({});
+    } catch {
+      /* pending */
+    }
+    try {
+      LazyComponent({});
+    } catch {
+      /* pending */
+    }
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the resolved component after the factory promise resolves', async () => {
+    const MockComp = props => createElement('span', null, props.label ?? 'loaded');
+    const factory = () => Promise.resolve({ default: MockComp });
+    const LazyComponent = lazy(factory);
+
+    let thrownPromise;
+    try {
+      LazyComponent({});
+    } catch (p) {
+      thrownPromise = p;
+    }
+    await thrownPromise;
+
+    const result = LazyComponent({ label: 'hi' });
+    expect(isValidElement(result)).toBe(true);
+    expect(result.type).toBe(MockComp);
+  });
+
+  it('throws the rejection reason after the factory promise rejects', async () => {
+    const reason = new Error('load failed');
+    const factory = () => Promise.reject(reason);
+    const LazyComponent = lazy(factory);
+
+    let thrownPromise;
+    try {
+      LazyComponent({});
+    } catch (p) {
+      thrownPromise = p;
+    }
+    await thrownPromise;
+
+    expect(() => LazyComponent({})).toThrow(reason);
+  });
+});
+
+describe('Suspense', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('renders children when not suspended', () => {
+    render(
+      createElement(
+        Suspense,
+        { fallback: createElement('span', null, 'loading') },
+        createElement('div', null, 'content')
+      ),
+      container
+    );
+    expect(container.textContent).toBe('content');
+  });
+
+  it('renders fallback when a child throws a Promise, then children after resolution', async () => {
+    let resolvePromise;
+    const suspensePromise = new Promise(r => {
+      resolvePromise = r;
+    });
+    let shouldThrow = true;
+    const Child = () => {
+      if (shouldThrow) throw suspensePromise;
+      return createElement('span', null, 'loaded');
+    };
+
+    render(
+      createElement(Suspense, { fallback: createElement('span', null, 'loading') }, createElement(Child, {})),
+      container
+    );
+
+    await flushMicrotasks();
+    expect(container.textContent).toBe('loading');
+
+    shouldThrow = false;
+    resolvePromise();
+    await flushMicrotasks();
+    expect(container.textContent).toBe('loaded');
+  });
+
+  it('tracks multiple concurrent promises independently', async () => {
+    let resolveA, resolveB;
+    const promiseA = new Promise(r => {
+      resolveA = r;
+    });
+    const promiseB = new Promise(r => {
+      resolveB = r;
+    });
+
+    let throwA = true;
+    let throwB = true;
+
+    const ChildA = () => {
+      if (throwA) throw promiseA;
+      return createElement('span', null, 'A');
+    };
+    const ChildB = () => {
+      if (throwB) throw promiseB;
+      return createElement('span', null, 'B');
+    };
+
+    render(
+      createElement(
+        Suspense,
+        { fallback: createElement('span', null, 'loading') },
+        createElement('div', null, createElement(ChildA, {}), createElement(ChildB, {}))
+      ),
+      container
+    );
+
+    await flushMicrotasks();
+    expect(container.textContent).toBe('loading');
+
+    // Resolve A first — B is still pending, must stay on fallback
+    throwA = false;
+    resolveA();
+    await flushMicrotasks();
+    expect(container.textContent).toBe('loading');
+
+    // Resolve B — both done, show children
+    throwB = false;
+    resolveB();
+    await flushMicrotasks();
+    expect(container.textContent).toBe('AB');
+  });
+});

--- a/src/test/compat/hooks.test.js
+++ b/src/test/compat/hooks.test.js
@@ -1,0 +1,436 @@
+import { withSyncRerender } from '@simpreact/internal';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createElement } from '../../main/compat/core.js';
+import { render } from '../../main/compat/dom.js';
+import {
+  useCallback,
+  useDebugValue,
+  useId,
+  useImperativeHandle,
+  useMemo,
+  useReducer,
+  useSyncExternalStore,
+} from '../../main/compat/hooks.js';
+import { renderRuntime } from '../../main/compat/index.js';
+
+describe('useReducer', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('returns initial state and a dispatch function (no initializer)', () => {
+    let state, dispatch;
+    const Comp = () => {
+      [state, dispatch] = useReducer((s, a) => s + a, 10);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(state).toBe(10);
+    expect(typeof dispatch).toBe('function');
+  });
+
+  it('calls initializer(initializerArg) when initializer is provided', () => {
+    let state;
+    const Comp = () => {
+      [state] = useReducer(
+        (s, a) => s + a,
+        5,
+        n => n * 2
+      );
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(state).toBe(10);
+  });
+
+  it('dispatch applies the reducer and triggers a re-render', () => {
+    let state, dispatch;
+    const Comp = () => {
+      [state, dispatch] = useReducer((s, a) => s + a, 0);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(renderRuntime, () => dispatch(5));
+    expect(state).toBe(5);
+    withSyncRerender(renderRuntime, () => dispatch(3));
+    expect(state).toBe(8);
+  });
+
+  it('dispatch skips re-render when new state is Object.is equal to current', () => {
+    let renderCount = 0;
+    let dispatch;
+    const Comp = () => {
+      renderCount++;
+      [, dispatch] = useReducer((_s, a) => a, 42);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(renderCount).toBe(1);
+    withSyncRerender(renderRuntime, () => dispatch(42));
+    expect(renderCount).toBe(1);
+  });
+
+  it('reducer always sees the latest reducer reference', () => {
+    let reducerVersion = 'v1';
+    let state, dispatch;
+    const Comp = () => {
+      [state, dispatch] = useReducer((s, _a) => `${s}-${reducerVersion}`, 'start');
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    reducerVersion = 'v2';
+    withSyncRerender(renderRuntime, () => dispatch('action'));
+    expect(state).toBe('start-v2');
+  });
+});
+
+describe('useId', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('returns a non-empty string', () => {
+    let id;
+    const Comp = () => {
+      id = useId();
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('uses the default "id" prefix', () => {
+    let id;
+    const Comp = () => {
+      id = useId();
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(id).toMatch(/^id-\d+$/);
+  });
+
+  it('uses a custom prefix when provided', () => {
+    let id;
+    const Comp = () => {
+      id = useId('tooltip');
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(id).toMatch(/^tooltip-\d+$/);
+  });
+
+  it('returns the same id on re-render', () => {
+    const ids = [];
+    const Comp = () => {
+      ids.push(useId());
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    const firstId = ids[0];
+    render(createElement(Comp, {}), container);
+    expect(ids[ids.length - 1]).toBe(firstId);
+  });
+
+  it('two different components get different ids', () => {
+    let id1, id2;
+    const CompA = () => {
+      id1 = useId();
+      return createElement('div');
+    };
+    const CompB = () => {
+      id2 = useId();
+      return createElement('div');
+    };
+    const containerA = document.createElement('div');
+    const containerB = document.createElement('div');
+    document.body.appendChild(containerA);
+    document.body.appendChild(containerB);
+    render(createElement(CompA, {}), containerA);
+    render(createElement(CompB, {}), containerB);
+    expect(id1).not.toBe(id2);
+    render(null, containerA);
+    render(null, containerB);
+    containerA.remove();
+    containerB.remove();
+  });
+});
+
+describe('useMemo', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('runs the factory on mount and returns its result', () => {
+    const factory = vi.fn(() => 99);
+    let result;
+    const Comp = () => {
+      result = useMemo(factory, []);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result).toBe(99);
+  });
+
+  it('does not re-run factory when deps are the same', () => {
+    const factory = vi.fn(() => Math.random());
+    let capturedValue;
+    let dispatch;
+    const Comp = () => {
+      const [count, set] = useReducer(s => s + 1, 0);
+      dispatch = set;
+      capturedValue = useMemo(factory, [0]);
+      void count;
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    const first = capturedValue;
+    withSyncRerender(renderRuntime, () => dispatch(null));
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(capturedValue).toBe(first);
+  });
+
+  it('re-runs factory when a dep changes', () => {
+    const factory = vi.fn(dep => dep * 2);
+    let capturedValue;
+    let dispatch;
+    const Comp = () => {
+      const [dep, set] = useReducer((_s, a) => a, 1);
+      dispatch = set;
+      capturedValue = useMemo(() => factory(dep), [dep]);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(capturedValue).toBe(2);
+    withSyncRerender(renderRuntime, () => dispatch(5));
+    expect(capturedValue).toBe(10);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('useCallback', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('returns the same function reference when deps are stable', () => {
+    const fn = () => 42;
+    const captured = [];
+    let dispatch;
+    const Comp = () => {
+      const [count, set] = useReducer(s => s + 1, 0);
+      dispatch = set;
+      captured.push(useCallback(fn, []));
+      void count;
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(renderRuntime, () => dispatch(null));
+    expect(captured[0]).toBe(fn);
+    expect(captured[1]).toBe(fn);
+    expect(captured[0]).toBe(captured[1]);
+  });
+
+  it('returns a new function reference when deps change', () => {
+    const captured = [];
+    let dispatch;
+    const Comp = () => {
+      const [dep, set] = useReducer((_s, a) => a, 1);
+      dispatch = set;
+      captured.push(useCallback(() => dep, [dep]));
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(renderRuntime, () => dispatch(2));
+    expect(captured.length).toBe(2);
+    expect(captured[0]).not.toBe(captured[1]);
+  });
+});
+
+describe('useImperativeHandle', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('sets ref.current to the init() result (object ref)', () => {
+    const ref = { current: null };
+    const handle = { focus: vi.fn() };
+    const Comp = () => {
+      useImperativeHandle(ref, () => handle, []);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(ref.current).toBe(handle);
+  });
+
+  it('calls function ref with the init() result', () => {
+    const calls = [];
+    const handle = { blur: vi.fn() };
+    const Comp = () => {
+      useImperativeHandle(
+        val => calls.push(val),
+        () => handle,
+        []
+      );
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(calls).toEqual([handle]);
+  });
+
+  it('does nothing when ref is null', () => {
+    const Comp = () => {
+      useImperativeHandle(null, () => ({ noop: true }), []);
+      return createElement('div');
+    };
+    expect(() => render(createElement(Comp, {}), container)).not.toThrow();
+  });
+});
+
+describe('useSyncExternalStore', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  function makeStore(initial) {
+    let value = initial;
+    let listener = null;
+    return {
+      get value() {
+        return value;
+      },
+      set value(v) {
+        value = v;
+      },
+      subscribe: cb => {
+        listener = cb;
+        return () => {
+          listener = null;
+        };
+      },
+      notify: () => listener?.(),
+      getSnapshot: () => value,
+    };
+  }
+
+  it('returns the initial snapshot on mount', () => {
+    const store = makeStore(7);
+    let captured;
+    const Comp = () => {
+      captured = useSyncExternalStore(store.subscribe, store.getSnapshot);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(captured).toBe(7);
+  });
+
+  it('calls subscribe during mount', () => {
+    const subscribe = vi.fn(() => () => {});
+    const getSnapshot = vi.fn(() => 0);
+    const Comp = () => {
+      useSyncExternalStore(subscribe, getSnapshot);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(subscribe).toHaveBeenCalledOnce();
+  });
+
+  it('triggers a re-render when the snapshot changes', () => {
+    const store = makeStore(0);
+    let snapshot;
+    const Comp = () => {
+      snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot);
+      return createElement('div', null, String(snapshot));
+    };
+    render(createElement(Comp, {}), container);
+    expect(snapshot).toBe(0);
+
+    store.value = 99;
+    withSyncRerender(renderRuntime, () => store.notify());
+    expect(snapshot).toBe(99);
+  });
+
+  it('does not re-render when snapshot is unchanged', () => {
+    const store = makeStore(5);
+    let renderCount = 0;
+    const Comp = () => {
+      renderCount++;
+      useSyncExternalStore(store.subscribe, store.getSnapshot);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(renderCount).toBe(1);
+
+    withSyncRerender(renderRuntime, () => store.notify());
+    expect(renderCount).toBe(1);
+  });
+
+  it('unsubscribes when the component unmounts', () => {
+    const store = makeStore(0);
+    const unsubscribe = vi.fn();
+    const subscribe = vi.fn(() => unsubscribe);
+    const Comp = () => {
+      useSyncExternalStore(subscribe, store.getSnapshot);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    render(null, container);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+});
+
+describe('useDebugValue', () => {
+  it('is a no-op that does not throw', () => {
+    expect(() => useDebugValue('debug info')).not.toThrow();
+    expect(() => useDebugValue(42, v => `formatted:${v}`)).not.toThrow();
+  });
+});

--- a/src/test/compat/renderRuntime.test.js
+++ b/src/test/compat/renderRuntime.test.js
@@ -1,0 +1,120 @@
+import { withSyncRerender } from '@simpreact/internal';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createElement } from '../../main/compat/core.js';
+import { render } from '../../main/compat/dom.js';
+import { renderRuntime } from '../../main/compat/index.js';
+
+describe('compat renderRuntime renderer', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('calls a plain function component with its props', () => {
+    const received = [];
+    const FC = props => {
+      received.push(props);
+      return createElement('div', null, props.label);
+    };
+    render(createElement(FC, { label: 'hello' }), container);
+    expect(received[0]).toMatchObject({ label: 'hello' });
+    expect(container.textContent).toBe('hello');
+  });
+
+  it('instantiates a class with isReactComponent=true and calls render()', () => {
+    class MyComponent {
+      constructor(props) {
+        this.props = props;
+      }
+      render() {
+        return createElement('span', null, this.props.text);
+      }
+    }
+    MyComponent.prototype.isReactComponent = true;
+    render(createElement(MyComponent, { text: 'class-component' }), container);
+    expect(container.textContent).toBe('class-component');
+  });
+
+  it('instantiates a class with a render() method (no isReactComponent) and calls render()', () => {
+    class LegacyComponent {
+      constructor(props) {
+        this.props = props;
+      }
+      render() {
+        return createElement('p', null, this.props.value);
+      }
+    }
+    render(createElement(LegacyComponent, { value: 'legacy' }), container);
+    expect(container.textContent).toBe('legacy');
+  });
+
+  it('persists the instance across re-renders (state is not reset)', () => {
+    let capturedInst;
+    class Stateful {
+      constructor(props) {
+        this.props = props;
+        this.state = { x: 1 };
+        capturedInst = this;
+      }
+      render() {
+        return createElement('span', null, String(this.state.x));
+      }
+    }
+    Stateful.prototype.isReactComponent = true;
+
+    render(createElement(Stateful, {}), container);
+    expect(container.textContent).toBe('1');
+
+    // Mutate state directly and trigger a re-render; the same instance must be reused
+    capturedInst.state = { x: 99 };
+    withSyncRerender(renderRuntime, () => capturedInst.forceUpdate());
+    expect(container.textContent).toBe('99');
+  });
+
+  it('injects setState that merges state and triggers a re-render', () => {
+    let capturedInst;
+    class Counter {
+      constructor(props) {
+        this.props = props;
+        this.state = { count: 0 };
+        capturedInst = this;
+      }
+      render() {
+        return createElement('span', null, String(this.state.count));
+      }
+    }
+    Counter.prototype.isReactComponent = true;
+
+    render(createElement(Counter, {}), container);
+    expect(container.textContent).toBe('0');
+
+    withSyncRerender(renderRuntime, () => capturedInst.setState({ count: 7 }));
+    expect(container.textContent).toBe('7');
+  });
+
+  it('setState with an updater function receives previous state', () => {
+    let capturedInst;
+    class Counter {
+      constructor(props) {
+        this.props = props;
+        this.state = { n: 10 };
+        capturedInst = this;
+      }
+      render() {
+        return createElement('span', null, String(this.state.n));
+      }
+    }
+    Counter.prototype.isReactComponent = true;
+
+    render(createElement(Counter, {}), container);
+    withSyncRerender(renderRuntime, () => capturedInst.setState(prev => ({ n: prev.n * 2 })));
+    expect(container.textContent).toBe('20');
+  });
+});

--- a/src/test/context/context.test.ts
+++ b/src/test/context/context.test.ts
@@ -1,0 +1,390 @@
+import { memo } from '@simpreact/core';
+import { createElement, createRenderRuntime, withSyncRerender } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createCreateContext, createUseContext } from '../../main/context/index.js';
+import { domAdapter } from '../../main/dom/index.js';
+import { createRenderer } from '../../main/dom/render.js';
+import { createUseState } from '../../main/hooks/index.js';
+
+const flushMicrotasks = () => new Promise<void>(r => setTimeout(r, 0));
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('createCreateContext — Provider and Consumer', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+  let container: HTMLDivElement;
+  let createContext: ReturnType<typeof createCreateContext>;
+  let useState: ReturnType<typeof createUseState>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    createContext = createCreateContext(runtime);
+    useState = createUseState(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('returns an object with Provider, Consumer, and defaultValue', () => {
+    const ctx = createContext(42);
+    expect(typeof ctx.Provider).toBe('function');
+    expect(typeof ctx.Consumer).toBe('function');
+    expect(ctx.defaultValue).toBe(42);
+  });
+
+  it('Consumer returns defaultValue when no Provider is above it', () => {
+    const ctx = createContext('fallback');
+    let received: unknown;
+    const Comp = () =>
+      createElement(ctx.Consumer, {
+        children: (v: unknown) => {
+          received = v;
+          return createElement('span');
+        },
+      });
+    render(createElement(Comp, {}), container);
+    expect(received).toBe('fallback');
+  });
+
+  it('Consumer returns the value provided by Provider', () => {
+    const ctx = createContext(0);
+    let received: unknown;
+    const Comp = () =>
+      createElement(
+        ctx.Provider,
+        { value: 99 },
+        createElement(ctx.Consumer, {
+          children: (v: unknown) => {
+            received = v;
+            return createElement('span');
+          },
+        })
+      );
+    render(createElement(Comp, {}), container);
+    expect(received).toBe(99);
+  });
+
+  it('Consumer receives updated value when Provider value changes (patch cascade)', () => {
+    const ctx = createContext('a');
+    let setState: any;
+    const Parent = () => {
+      const [val, set] = useState('a');
+      setState = set;
+      return createElement(
+        ctx.Provider,
+        { value: val },
+        createElement(ctx.Consumer, {
+          children: (v: unknown) => createElement('span', null, v as string),
+        })
+      );
+    };
+    render(createElement(Parent, {}), container);
+    expect(container.textContent).toBe('a');
+
+    withSyncRerender(runtime, () => setState('b'));
+    expect(container.textContent).toBe('b');
+  });
+
+  it('memoized Consumer re-renders via subscription when Provider value changes', async () => {
+    const ctx = createContext('old');
+    let setState: any;
+    let watcherRenderCount = 0;
+
+    const useContext = createUseContext(runtime);
+
+    const Watcher = memo(() => {
+      watcherRenderCount++;
+      const val = useContext(ctx);
+      return createElement('span', null, val as string);
+    });
+
+    const Parent = () => {
+      const [val, set] = useState('old');
+      setState = set;
+      return createElement(ctx.Provider, { value: val }, createElement(Watcher, {}));
+    };
+
+    render(createElement(Parent, {}), container);
+    expect(watcherRenderCount).toBe(1);
+    expect(container.textContent).toBe('old');
+
+    withSyncRerender(runtime, () => setState('new'));
+    // Watcher is memo'd — normal patch skips it. Subscription re-render is async.
+    expect(watcherRenderCount).toBe(1);
+
+    await flushMicrotasks();
+    expect(container.textContent).toBe('new');
+    expect(watcherRenderCount).toBe(2);
+  });
+
+  it('memoized Consumer does not re-render when Provider emits the same Object.is value', async () => {
+    const ctx = createContext(0);
+    let setCounter: any;
+    let watcherRenderCount = 0;
+
+    const useContext = createUseContext(runtime);
+
+    const Watcher = memo(() => {
+      watcherRenderCount++;
+      useContext(ctx);
+      return createElement('div');
+    });
+
+    const Parent = () => {
+      const [_counter, set] = useState(0);
+      setCounter = set;
+      return createElement(ctx.Provider, { value: 42 }, createElement(Watcher, {}));
+    };
+
+    render(createElement(Parent, {}), container);
+    expect(watcherRenderCount).toBe(1);
+
+    // Re-render Parent — Provider receives the same value (42 === 42)
+    withSyncRerender(runtime, () => setCounter(1));
+    await flushMicrotasks();
+
+    expect(watcherRenderCount).toBe(1);
+  });
+
+  it('multiple Consumers are all notified when Provider value changes', async () => {
+    const ctx = createContext('x');
+    let setState: any;
+    const useContext = createUseContext(runtime);
+
+    let countA = 0;
+    let countB = 0;
+
+    const WatcherA = memo(() => {
+      countA++;
+      useContext(ctx);
+      return createElement('span', { id: 'a' });
+    });
+
+    const WatcherB = memo(() => {
+      countB++;
+      useContext(ctx);
+      return createElement('span', { id: 'b' });
+    });
+
+    const Parent = () => {
+      const [val, set] = useState('x');
+      setState = set;
+      return createElement(
+        ctx.Provider,
+        { value: val },
+        createElement('div', null, createElement(WatcherA, {}), createElement(WatcherB, {}))
+      );
+    };
+
+    render(createElement(Parent, {}), container);
+    expect(countA).toBe(1);
+    expect(countB).toBe(1);
+
+    withSyncRerender(runtime, () => setState('y'));
+    await flushMicrotasks();
+
+    expect(countA).toBe(2);
+    expect(countB).toBe(2);
+  });
+
+  it('nested Providers: inner value shadows outer value for descendants', () => {
+    const ctx = createContext('default');
+    let outerReceived: unknown;
+    let innerReceived: unknown;
+
+    const Inner = () =>
+      createElement(ctx.Consumer, {
+        children: (v: unknown) => {
+          innerReceived = v;
+          return createElement('span', null, v as string);
+        },
+      });
+
+    const Outer = () =>
+      createElement(ctx.Consumer, {
+        children: (v: unknown) => {
+          outerReceived = v;
+          return createElement('span');
+        },
+      });
+
+    const Root = () =>
+      createElement(
+        ctx.Provider,
+        { value: 'outer' },
+        createElement(
+          'div',
+          null,
+          createElement(Outer, {}),
+          createElement(ctx.Provider, { value: 'inner' }, createElement(Inner, {}))
+        )
+      );
+
+    render(createElement(Root, {}), container);
+    expect(outerReceived).toBe('outer');
+    expect(innerReceived).toBe('inner');
+  });
+});
+
+describe('createUseContext', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+  let container: HTMLDivElement;
+  let createContext: ReturnType<typeof createCreateContext>;
+  let useContext: ReturnType<typeof createUseContext>;
+  let useState: ReturnType<typeof createUseState>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    createContext = createCreateContext(runtime);
+    useContext = createUseContext(runtime);
+    useState = createUseState(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('returns defaultValue when no Provider is in the tree', () => {
+    const ctx = createContext('missing');
+    let received: unknown;
+    const Comp = () => {
+      received = useContext(ctx);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(received).toBe('missing');
+  });
+
+  it('returns the current provided value from the nearest Provider', () => {
+    const ctx = createContext(0);
+    let received: unknown;
+    const Child = () => {
+      received = useContext(ctx);
+      return createElement('div');
+    };
+    const Root = () => createElement(ctx.Provider, { value: 7 }, createElement(Child, {}));
+    render(createElement(Root, {}), container);
+    expect(received).toBe(7);
+  });
+
+  it('subscribes the consuming component: async re-render when Provider value changes', async () => {
+    const ctx = createContext('init');
+    let setState: any;
+    let renderCount = 0;
+
+    const Watcher = memo(() => {
+      renderCount++;
+      const val = useContext(ctx);
+      return createElement('span', null, val as string);
+    });
+
+    const Parent = () => {
+      const [val, set] = useState('init');
+      setState = set;
+      return createElement(ctx.Provider, { value: val }, createElement(Watcher, {}));
+    };
+
+    render(createElement(Parent, {}), container);
+    expect(renderCount).toBe(1);
+    expect(container.textContent).toBe('init');
+
+    withSyncRerender(runtime, () => setState('changed'));
+    expect(renderCount).toBe(1); // memo blocked patch cascade
+
+    await flushMicrotasks();
+    expect(container.textContent).toBe('changed');
+    expect(renderCount).toBe(2);
+  });
+
+  it('does not trigger subscription re-render when Provider value is Object.is equal', async () => {
+    const ctx = createContext(0);
+    let setTick: any;
+    let renderCount = 0;
+
+    const Watcher = memo(() => {
+      renderCount++;
+      useContext(ctx);
+      return createElement('div');
+    });
+
+    const Parent = () => {
+      const [tick, set] = useState(0);
+      setTick = set;
+      void tick;
+      return createElement(ctx.Provider, { value: 'stable' }, createElement(Watcher, {}));
+    };
+
+    render(createElement(Parent, {}), container);
+    expect(renderCount).toBe(1);
+
+    withSyncRerender(runtime, () => setTick(1));
+    await flushMicrotasks();
+
+    expect(renderCount).toBe(1);
+  });
+
+  it('two different contexts in the same component are independent', () => {
+    const ctxA = createContext('a-default');
+    const ctxB = createContext('b-default');
+    let valA: unknown;
+    let valB: unknown;
+
+    const Child = () => {
+      valA = useContext(ctxA);
+      valB = useContext(ctxB);
+      return createElement('div');
+    };
+
+    const Root = () =>
+      createElement(
+        ctxA.Provider,
+        { value: 'A' },
+        createElement(ctxB.Provider, { value: 'B' }, createElement(Child, {}))
+      );
+
+    render(createElement(Root, {}), container);
+    expect(valA).toBe('A');
+    expect(valB).toBe('B');
+  });
+
+  it('returns the latest value on every re-render after context changes', async () => {
+    const ctx = createContext(0);
+    let setState: any;
+    const values: unknown[] = [];
+
+    const Watcher = memo(() => {
+      values.push(useContext(ctx));
+      return createElement('div');
+    });
+
+    const Parent = () => {
+      const [val, set] = useState(0);
+      setState = set;
+      return createElement(ctx.Provider, { value: val }, createElement(Watcher, {}));
+    };
+
+    render(createElement(Parent, {}), container);
+
+    withSyncRerender(runtime, () => setState(1));
+    await flushMicrotasks();
+
+    withSyncRerender(runtime, () => setState(2));
+    await flushMicrotasks();
+
+    expect(values).toEqual([0, 1, 2]);
+  });
+});

--- a/src/test/dom/attach-element-to-dom.test.ts
+++ b/src/test/dom/attach-element-to-dom.test.ts
@@ -1,0 +1,78 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createTextElement } from '../../main/core/createElement.js';
+import { attachElementToDom, detachElementFromDom, getElementFromDom } from '../../main/dom/attach-element-to-dom.js';
+import { domAdapter } from '../../main/dom/index.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('attach-element-to-dom', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let dom: HTMLElement;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    dom = document.createElement('div');
+  });
+
+  describe('attachElementToDom', () => {
+    it('stores a HOST element and retrieves it by the same DOM node', () => {
+      const el = createElement('div');
+      attachElementToDom(el, dom, runtime);
+      expect(getElementFromDom(dom, runtime)).toBe(el);
+    });
+
+    it('does not store TEXT elements', () => {
+      const el = createTextElement('hello');
+      attachElementToDom(el, dom, runtime);
+      expect(getElementFromDom(dom, runtime)).toBeNull();
+    });
+  });
+
+  describe('getElementFromDom', () => {
+    it('returns null when target is null', () => {
+      expect(getElementFromDom(null, runtime)).toBeNull();
+    });
+
+    it('returns element when target is directly mapped', () => {
+      const el = createElement('div');
+      attachElementToDom(el, dom, runtime);
+      expect(getElementFromDom(dom, runtime)).toBe(el);
+    });
+
+    it('walks up parentElement until a mapped ancestor is found', () => {
+      const el = createElement('div');
+      const parent = document.createElement('div');
+      const child = document.createElement('span');
+      parent.appendChild(child);
+      attachElementToDom(el, parent, runtime);
+      expect(getElementFromDom(child, runtime)).toBe(el);
+    });
+
+    it('returns null when no mapped ancestor exists in the tree', () => {
+      const unmapped = document.createElement('div');
+      expect(getElementFromDom(unmapped, runtime)).toBeNull();
+    });
+  });
+
+  describe('detachElementFromDom', () => {
+    it('removes the entry so subsequent lookups return null', () => {
+      const el = createElement('div');
+      attachElementToDom(el, dom, runtime);
+      detachElementFromDom(dom, runtime);
+      expect(getElementFromDom(dom, runtime)).toBeNull();
+    });
+  });
+
+  describe('runtime isolation', () => {
+    it('two runtimes maintain independent maps', () => {
+      const runtime2 = makeRuntime();
+      const el = createElement('div');
+      attachElementToDom(el, dom, runtime);
+      expect(getElementFromDom(dom, runtime2)).toBeNull();
+    });
+  });
+});

--- a/src/test/dom/domAdapter.test.ts
+++ b/src/test/dom/domAdapter.test.ts
@@ -1,0 +1,235 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { domAdapter } from '../../main/dom/index.js';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('domAdapter', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+  });
+
+  // -------------------------------------------------------------------------
+  // createReference
+  // -------------------------------------------------------------------------
+
+  describe('createReference', () => {
+    it('creates an HTML element when namespace is absent', () => {
+      const el = domAdapter.createReference('div', undefined);
+      expect(el.tagName.toLowerCase()).toBe('div');
+      expect(el instanceof HTMLDivElement).toBe(true);
+    });
+
+    it('creates an SVG element when SVG namespace is provided', () => {
+      const el = domAdapter.createReference('circle', SVG_NS);
+      expect(el.namespaceURI).toBe(SVG_NS);
+      expect(el.tagName).toBe('circle');
+    });
+
+    it('creates element via createElementNS when any namespace is given', () => {
+      const el = domAdapter.createReference('rect', SVG_NS);
+      expect(el.namespaceURI).toBe(SVG_NS);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createTextReference
+  // -------------------------------------------------------------------------
+
+  describe('createTextReference', () => {
+    it('creates a Text node with the correct content', () => {
+      const node = domAdapter.createTextReference('hello');
+      expect(node).toBeInstanceOf(Text);
+      expect(node.nodeValue).toBe('hello');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setClassname
+  // -------------------------------------------------------------------------
+
+  describe('setClassname', () => {
+    it('removes the class attribute when className is null', () => {
+      const el = document.createElement('div');
+      el.className = 'old';
+      domAdapter.setClassname(el, null, undefined);
+      expect(el.getAttribute('class')).toBeNull();
+    });
+
+    it('removes the class attribute when className is empty string', () => {
+      const el = document.createElement('div');
+      el.className = 'old';
+      domAdapter.setClassname(el, '', undefined);
+      expect(el.getAttribute('class')).toBeNull();
+    });
+
+    it('sets className property in HTML context', () => {
+      const el = document.createElement('div');
+      domAdapter.setClassname(el, 'foo bar', undefined);
+      expect(el.className).toBe('foo bar');
+    });
+
+    it('uses setAttribute in SVG context', () => {
+      const el = document.createElementNS(SVG_NS, 'svg') as unknown as SVGSVGElement & HTMLElement;
+      domAdapter.setClassname(el, 'svg-class', SVG_NS);
+      expect(el.getAttribute('class')).toBe('svg-class');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setTextContent
+  // -------------------------------------------------------------------------
+
+  describe('setTextContent', () => {
+    it('sets textContent when referenceHasOnlyTextElement is falsy', () => {
+      const el = document.createElement('p');
+      domAdapter.setTextContent(el, 'hello');
+      expect(el.textContent).toBe('hello');
+    });
+
+    it('sets firstChild.nodeValue when referenceHasOnlyTextElement is true', () => {
+      const el = document.createElement('p');
+      el.appendChild(document.createTextNode('old'));
+      domAdapter.setTextContent(el, 'new', true);
+      expect(el.firstChild!.nodeValue).toBe('new');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // insertOrAppend
+  // -------------------------------------------------------------------------
+
+  describe('insertOrAppend', () => {
+    it('appends child when before is null', () => {
+      const parent = document.createElement('div');
+      const child = document.createElement('span');
+      domAdapter.insertOrAppend(parent, child, null);
+      expect(parent.firstChild).toBe(child);
+    });
+
+    it('inserts child before the given node', () => {
+      const parent = document.createElement('div');
+      const existing = document.createElement('b');
+      parent.appendChild(existing);
+      const child = document.createElement('span');
+      domAdapter.insertOrAppend(parent, child, existing);
+      expect(parent.firstChild).toBe(child);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // removeChild
+  // -------------------------------------------------------------------------
+
+  describe('removeChild', () => {
+    it('removes the child from parent', () => {
+      const parent = document.createElement('div');
+      const child = document.createElement('span');
+      parent.appendChild(child);
+      domAdapter.removeChild(parent, child);
+      expect(parent.childNodes.length).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // replaceChild
+  // -------------------------------------------------------------------------
+
+  describe('replaceChild', () => {
+    it('replaces the old node with the new one', () => {
+      const parent = document.createElement('div');
+      const old = document.createElement('span');
+      const replacement = document.createElement('b');
+      parent.appendChild(old);
+      domAdapter.replaceChild(parent, replacement, old);
+      expect(parent.firstChild).toBe(replacement);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // clearNode
+  // -------------------------------------------------------------------------
+
+  describe('clearNode', () => {
+    it('clears all children via textContent', () => {
+      const el = document.createElement('div');
+      el.innerHTML = '<span>one</span><span>two</span>';
+      domAdapter.clearNode(el);
+      expect(el.textContent).toBe('');
+      expect(el.childNodes.length).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // attachElementToReference / getElementFromReference / detachElementFromReference
+  // -------------------------------------------------------------------------
+
+  describe('element ↔ reference map', () => {
+    it('stores and retrieves an element by its DOM reference', () => {
+      const el = createElement('div');
+      const dom = document.createElement('div');
+      domAdapter.attachElementToReference(el, dom, runtime);
+      expect(domAdapter.getElementFromReference(dom, runtime)).toBe(el);
+    });
+
+    it('getElementFromReference walks up the DOM when target is not directly mapped', () => {
+      const el = createElement('div');
+      const parent = document.createElement('div');
+      const child = document.createElement('span');
+      parent.appendChild(child);
+      domAdapter.attachElementToReference(el, parent, runtime);
+      expect(domAdapter.getElementFromReference(child, runtime)).toBe(el);
+    });
+
+    it('returns null after detach', () => {
+      const el = createElement('div');
+      const dom = document.createElement('div');
+      domAdapter.attachElementToReference(el, dom, runtime);
+      domAdapter.detachElementFromReference(dom, runtime);
+      expect(domAdapter.getElementFromReference(dom, runtime)).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getHostNamespaces
+  // -------------------------------------------------------------------------
+
+  describe('getHostNamespaces', () => {
+    it('returns SVG namespace for self and children when element is <svg>', () => {
+      const el = createElement('svg');
+      const ns = domAdapter.getHostNamespaces(el, undefined);
+      expect(ns).toEqual({ self: SVG_NS, children: SVG_NS });
+    });
+
+    it('returns SVG namespace for self and null for children when element is <foreignObject>', () => {
+      const el = createElement('foreignObject');
+      const ns = domAdapter.getHostNamespaces(el, undefined);
+      expect(ns).toEqual({ self: SVG_NS, children: null });
+    });
+
+    it('propagates current namespace for elements inside SVG', () => {
+      const el = createElement('circle');
+      const ns = domAdapter.getHostNamespaces(el, SVG_NS);
+      expect(ns).toEqual({ self: SVG_NS, children: SVG_NS });
+    });
+
+    it('returns null for plain HTML elements with no namespace', () => {
+      const el = createElement('div');
+      const ns = domAdapter.getHostNamespaces(el, undefined);
+      expect(ns).toBeNull();
+    });
+
+    it('returns null for plain HTML elements with HTML namespace', () => {
+      const el = createElement('div');
+      const ns = domAdapter.getHostNamespaces(el, 'http://www.w3.org/1999/xhtml');
+      expect(ns).toBeNull();
+    });
+  });
+});

--- a/src/test/dom/events.test.ts
+++ b/src/test/dom/events.test.ts
@@ -1,0 +1,386 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  dispatchDelegatedEvent,
+  isPropNameEventName,
+  patchDelegatedEvent,
+  patchEvent,
+  patchNormalEvent,
+  SyntheticEvent,
+} from '../../main/dom/events.js';
+import { domAdapter } from '../../main/dom/index.js';
+import { createRenderer } from '../../main/dom/render.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+// ---------------------------------------------------------------------------
+// isPropNameEventName
+// ---------------------------------------------------------------------------
+
+describe('isPropNameEventName', () => {
+  it('returns true for strings starting with "on"', () => {
+    expect(isPropNameEventName('onClick')).toBe(true);
+    expect(isPropNameEventName('onChange')).toBe(true);
+    expect(isPropNameEventName('onInput')).toBe(true);
+  });
+
+  it('returns false for strings not starting with "on"', () => {
+    expect(isPropNameEventName('click')).toBe(false);
+    expect(isPropNameEventName('className')).toBe(false);
+    expect(isPropNameEventName('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SyntheticEvent
+// ---------------------------------------------------------------------------
+
+describe('SyntheticEvent', () => {
+  let nativeEvent: MouseEvent;
+  let synthetic: SyntheticEvent;
+
+  beforeEach(() => {
+    nativeEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    synthetic = new SyntheticEvent(nativeEvent);
+  });
+
+  it('exposes nativeEvent', () => {
+    expect(synthetic.nativeEvent).toBe(nativeEvent);
+  });
+
+  it('proxies .target to native event', () => {
+    expect(synthetic.target).toBe(nativeEvent.target);
+  });
+
+  it('proxies .type to native event', () => {
+    expect(synthetic.type).toBe('click');
+  });
+
+  it('proxies unknown properties to native event (primitive)', () => {
+    expect((synthetic as any).bubbles).toBe(true);
+  });
+
+  it('proxies unknown function properties bound to native event', () => {
+    const composed = (synthetic as any).composedPath;
+    expect(typeof composed).toBe('function');
+  });
+
+  it('stopPropagation sets isPropagationStopped and calls native', () => {
+    const spy = vi.spyOn(nativeEvent, 'stopPropagation');
+    synthetic.stopPropagation();
+    expect(synthetic.isPropagationStopped).toBe(true);
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('preventDefault sets _isDefaultPrevented and calls native', () => {
+    const spy = vi.spyOn(nativeEvent, 'preventDefault');
+    synthetic.preventDefault();
+    expect(synthetic._isDefaultPrevented).toBe(true);
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('isDefaultPrevented returns true after preventDefault', () => {
+    synthetic.preventDefault();
+    expect(synthetic.isDefaultPrevented()).toBe(true);
+  });
+
+  it('isDefaultPrevented returns false initially', () => {
+    expect(synthetic.isDefaultPrevented()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchNormalEvent
+// ---------------------------------------------------------------------------
+
+describe('patchNormalEvent', () => {
+  let dom: HTMLDivElement;
+
+  beforeEach(() => {
+    dom = document.createElement('div');
+  });
+
+  it('adds listener when transitioning from null to a function', () => {
+    const handler = vi.fn();
+    const spy = vi.spyOn(dom, 'addEventListener');
+    patchNormalEvent('scroll', null, handler, dom, false);
+    expect(spy).toHaveBeenCalledWith('scroll', handler, { capture: false });
+  });
+
+  it('removes old listener and adds new one when replacing', () => {
+    const prev = vi.fn();
+    const next = vi.fn();
+    const removeSpy = vi.spyOn(dom, 'removeEventListener');
+    const addSpy = vi.spyOn(dom, 'addEventListener');
+    patchNormalEvent('scroll', prev, next, dom, false);
+    expect(removeSpy).toHaveBeenCalledWith('scroll', prev, { capture: false });
+    expect(addSpy).toHaveBeenCalledWith('scroll', next, { capture: false });
+  });
+
+  it('removes listener when transitioning to null', () => {
+    const prev = vi.fn();
+    const removeSpy = vi.spyOn(dom, 'removeEventListener');
+    const addSpy = vi.spyOn(dom, 'addEventListener');
+    patchNormalEvent('scroll', prev, null, dom, false);
+    expect(removeSpy).toHaveBeenCalledWith('scroll', prev, { capture: false });
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes capture:true when isCapture is true', () => {
+    const handler = vi.fn();
+    const spy = vi.spyOn(dom, 'addEventListener');
+    patchNormalEvent('scroll', null, handler, dom, true);
+    expect(spy).toHaveBeenCalledWith('scroll', handler, { capture: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchDelegatedEvent
+// ---------------------------------------------------------------------------
+
+describe('patchDelegatedEvent', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let counts: any;
+  let addSpy: ReturnType<typeof vi.spyOn>;
+  let removeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    counts = { click: 0 };
+    addSpy = vi.spyOn(document, 'addEventListener');
+    removeSpy = vi.spyOn(document, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it('adds document listener when first handler is registered', () => {
+    patchDelegatedEvent('click', null, vi.fn(), counts, runtime);
+    expect(counts.click).toBe(1);
+    expect(addSpy).toHaveBeenCalledWith('click', expect.any(Function));
+  });
+
+  it('does not add another document listener on second handler', () => {
+    patchDelegatedEvent('click', null, vi.fn(), counts, runtime);
+    addSpy.mockClear();
+    patchDelegatedEvent('click', null, vi.fn(), counts, runtime);
+    expect(counts.click).toBe(2);
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not remove document listener when count goes from 2 to 1', () => {
+    patchDelegatedEvent('click', null, vi.fn(), counts, runtime);
+    patchDelegatedEvent('click', null, vi.fn(), counts, runtime);
+    removeSpy.mockClear();
+    patchDelegatedEvent('click', vi.fn(), null, counts, runtime);
+    expect(counts.click).toBe(1);
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  it('removes document listener when count reaches zero', () => {
+    patchDelegatedEvent('click', null, vi.fn(), counts, runtime);
+    patchDelegatedEvent('click', vi.fn(), null, counts, runtime);
+    expect(counts.click).toBe(0);
+    expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function));
+  });
+
+  it('guard: does not decrement below zero or call removeEventListener when count is already 0', () => {
+    patchDelegatedEvent('click', vi.fn(), null, counts, runtime);
+    expect(counts.click).toBe(0);
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  it('two runtimes get independent dispatchers', () => {
+    const runtime2 = makeRuntime();
+    const counts2 = { click: 0 };
+    patchDelegatedEvent('click', null, vi.fn(), counts, runtime);
+    patchDelegatedEvent('click', null, vi.fn(), counts2 as any, runtime2);
+    const calls = addSpy.mock.calls.filter(c => c[0] === 'click');
+    const handlers = calls.map(c => c[1]);
+    expect(handlers[0]).not.toBe(handlers[1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchEvent routing
+// ---------------------------------------------------------------------------
+
+describe('patchEvent', () => {
+  let dom: HTMLDivElement;
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    dom = document.createElement('div');
+    runtime = makeRuntime();
+    vi.spyOn(document, 'addEventListener');
+    vi.spyOn(document, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('routes delegated events (onClick) to patchDelegatedEvent', () => {
+    const handler = vi.fn();
+    patchEvent('onClick', null, handler, dom, runtime);
+    expect(document.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+  });
+
+  it('routes capture variant (onClickCapture) to delegated path', () => {
+    const handler = vi.fn();
+    patchEvent('onClickCapture', null, handler, dom, runtime);
+    expect(document.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+  });
+
+  it('routes non-delegated events (onScroll) to patchNormalEvent', () => {
+    const handler = vi.fn();
+    const spy = vi.spyOn(dom, 'addEventListener');
+    patchEvent('onScroll', null, handler, dom, runtime);
+    expect(spy).toHaveBeenCalledWith('scroll', handler, { capture: false });
+  });
+
+  it('routes onScrollCapture to patchNormalEvent with capture:true', () => {
+    const handler = vi.fn();
+    const spy = vi.spyOn(dom, 'addEventListener');
+    patchEvent('onScrollCapture', null, handler, dom, runtime);
+    expect(spy).toHaveBeenCalledWith('scroll', handler, { capture: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatchDelegatedEvent
+// ---------------------------------------------------------------------------
+
+describe('dispatchDelegatedEvent', () => {
+  let container: HTMLDivElement;
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('fires the onClick handler on the clicked element', () => {
+    const onClick = vi.fn();
+    render(createElement('div', { onClick }), container);
+    const div = container.querySelector('div')!;
+    div.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('bubbles: fires parent onClick when child is clicked', () => {
+    const parentClick = vi.fn();
+    const childClick = vi.fn();
+    render(createElement('div', { onClick: parentClick }, createElement('span', { onClick: childClick })), container);
+    const span = container.querySelector('span')!;
+    span.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(childClick).toHaveBeenCalledOnce();
+    expect(parentClick).toHaveBeenCalledOnce();
+  });
+
+  it('fires child handler before parent (bubble order)', () => {
+    const order: string[] = [];
+    render(
+      createElement(
+        'div',
+        { onClick: () => order.push('parent') },
+        createElement('span', { onClick: () => order.push('child') })
+      ),
+      container
+    );
+    container.querySelector('span')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(order).toEqual(['child', 'parent']);
+  });
+
+  it('capture handlers fire before bubble handlers, in top-down order', () => {
+    const order: string[] = [];
+    render(
+      createElement(
+        'div',
+        { onClickCapture: () => order.push('parent-capture') },
+        createElement('span', { onClick: () => order.push('child-bubble') })
+      ),
+      container
+    );
+    container.querySelector('span')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(order[0]).toBe('parent-capture');
+    expect(order[1]).toBe('child-bubble');
+  });
+
+  it('stopPropagation halts remaining bubble handlers', () => {
+    const parentClick = vi.fn();
+    render(
+      createElement(
+        'div',
+        { onClick: parentClick },
+        createElement('span', { onClick: (e: SyntheticEvent) => e.stopPropagation() })
+      ),
+      container
+    );
+    container.querySelector('span')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('stopPropagation in capture phase halts remaining handlers', () => {
+    const childBubble = vi.fn();
+    render(
+      createElement(
+        'div',
+        { onClickCapture: (e: SyntheticEvent) => e.stopPropagation() },
+        createElement('span', { onClick: childBubble })
+      ),
+      container
+    );
+    container.querySelector('span')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(childBubble).not.toHaveBeenCalled();
+  });
+
+  it('event targeting a node outside the vdom fires no handlers', () => {
+    const onClick = vi.fn();
+    render(createElement('div', { onClick }), container);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onClick).not.toHaveBeenCalled();
+    outside.remove();
+  });
+
+  it('sets currentTarget on synthetic event to the element with handler', () => {
+    let capturedTarget: EventTarget | null = null;
+    render(
+      createElement('div', {
+        onClick: (e: SyntheticEvent) => {
+          capturedTarget = e.currentTarget;
+        },
+      }),
+      container
+    );
+    const div = container.querySelector('div')!;
+    div.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(capturedTarget).toBe(div);
+  });
+
+  it('dispatches directly via dispatchDelegatedEvent without going through document', () => {
+    const onClick = vi.fn();
+    render(createElement('div', { onClick }), container);
+    const div = container.querySelector('div')!;
+    const event = new MouseEvent('click', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: div, writable: false });
+    dispatchDelegatedEvent(event, runtime);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/src/test/dom/props/controlled/index.test.ts
+++ b/src/test/dom/props/controlled/index.test.ts
@@ -1,0 +1,181 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { domAdapter } from '../../../../main/dom/index.js';
+import {
+  addControlledFormElementEventHandlers,
+  isEventNameIgnored,
+  isFormElementControlled,
+  removeControlledFormElementEventHandlers,
+  syncControlledFormElementPropsWithAttrs,
+} from '../../../../main/dom/props/controlled/index.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('isFormElementControlled', () => {
+  it('returns true when value is non-null', () => {
+    expect(isFormElementControlled({ value: '' })).toBe(true);
+  });
+  it('returns true when checked is non-null', () => {
+    expect(isFormElementControlled({ checked: false })).toBe(true);
+  });
+  it('returns false when neither value nor checked is set', () => {
+    expect(isFormElementControlled({})).toBe(false);
+  });
+  it('returns false when value is null', () => {
+    expect(isFormElementControlled({ value: null })).toBe(false);
+  });
+});
+
+describe('isEventNameIgnored (dispatcher)', () => {
+  it('delegates to input logic for input elements', () => {
+    const el = createElement('input', { type: 'checkbox' });
+    expect(isEventNameIgnored(el, 'onChange')).toBe(true);
+    expect(isEventNameIgnored(el, 'onInput')).toBe(false);
+  });
+
+  it('delegates to select logic for select elements', () => {
+    const el = createElement('select');
+    expect(isEventNameIgnored(el, 'onChange')).toBe(true);
+    expect(isEventNameIgnored(el, 'onInput')).toBe(false);
+  });
+
+  it('delegates to textarea logic for textarea elements', () => {
+    const el = createElement('textarea');
+    expect(isEventNameIgnored(el, 'onChange')).toBe(true);
+    expect(isEventNameIgnored(el, 'onInput')).toBe(true);
+  });
+
+  it('returns false for unknown element types', () => {
+    const el = createElement('div');
+    expect(isEventNameIgnored(el, 'onChange')).toBe(false);
+  });
+});
+
+describe('addControlledFormElementEventHandlers', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+  });
+
+  it('adds handlers for input element', () => {
+    const el = createElement('input');
+    const dom = document.createElement('input');
+    el.reference = dom;
+    const spy = vi.spyOn(dom, 'addEventListener');
+    addControlledFormElementEventHandlers(el, runtime);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('adds handlers for select element', () => {
+    const el = createElement('select');
+    const dom = document.createElement('select');
+    el.reference = dom;
+    const spy = vi.spyOn(dom, 'addEventListener');
+    addControlledFormElementEventHandlers(el, runtime);
+    expect(spy).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('adds handlers for textarea element', () => {
+    const el = createElement('textarea');
+    const dom = document.createElement('textarea');
+    el.reference = dom;
+    const spy = vi.spyOn(dom, 'addEventListener');
+    addControlledFormElementEventHandlers(el, runtime);
+    const events = spy.mock.calls.map(c => c[0]);
+    expect(events).toContain('input');
+    expect(events).toContain('change');
+  });
+
+  it('is a no-op for unknown element types', () => {
+    const el = createElement('div');
+    el.reference = document.createElement('div');
+    expect(() => addControlledFormElementEventHandlers(el, runtime)).not.toThrow();
+  });
+});
+
+describe('removeControlledFormElementEventHandlers', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+  });
+
+  it('removes handlers for input element', () => {
+    const el = createElement('input');
+    const dom = document.createElement('input');
+    el.reference = dom;
+    addControlledFormElementEventHandlers(el, runtime);
+    const spy = vi.spyOn(dom, 'removeEventListener');
+    removeControlledFormElementEventHandlers(el, runtime);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('removes handlers for select element', () => {
+    const el = createElement('select');
+    const dom = document.createElement('select');
+    el.reference = dom;
+    addControlledFormElementEventHandlers(el, runtime);
+    const spy = vi.spyOn(dom, 'removeEventListener');
+    removeControlledFormElementEventHandlers(el, runtime);
+    expect(spy).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('removes handlers for textarea element', () => {
+    const el = createElement('textarea');
+    const dom = document.createElement('textarea');
+    el.reference = dom;
+    addControlledFormElementEventHandlers(el, runtime);
+    const spy = vi.spyOn(dom, 'removeEventListener');
+    removeControlledFormElementEventHandlers(el, runtime);
+    const events = spy.mock.calls.map(c => c[0]);
+    expect(events).toContain('input');
+    expect(events).toContain('change');
+  });
+
+  it('is a no-op for unknown element types', () => {
+    const el = createElement('div');
+    el.reference = document.createElement('div');
+    expect(() => removeControlledFormElementEventHandlers(el, runtime)).not.toThrow();
+  });
+});
+
+describe('syncControlledFormElementPropsWithAttrs', () => {
+  it('syncs input props', () => {
+    const el = createElement('input');
+    const dom = document.createElement('input');
+    el.reference = dom;
+    dom.value = 'old';
+    syncControlledFormElementPropsWithAttrs(el, { value: 'new' });
+    expect(dom.value).toBe('new');
+  });
+
+  it('syncs select props', () => {
+    const el = createElement('select');
+    const dom = document.createElement('select');
+    const opt = document.createElement('option');
+    opt.value = 'a';
+    dom.appendChild(opt);
+    el.reference = dom;
+    syncControlledFormElementPropsWithAttrs(el, { value: 'a' }, true);
+    expect(dom.options[0]!.selected).toBe(true);
+  });
+
+  it('syncs textarea props', () => {
+    const el = createElement('textarea');
+    const dom = document.createElement('textarea');
+    el.reference = dom;
+    dom.value = 'old';
+    syncControlledFormElementPropsWithAttrs(el, { value: 'new' });
+    expect(dom.value).toBe('new');
+  });
+
+  it('is a no-op for unknown element types', () => {
+    const el = createElement('div');
+    el.reference = document.createElement('div');
+    expect(() => syncControlledFormElementPropsWithAttrs(el, {})).not.toThrow();
+  });
+});

--- a/src/test/dom/props/controlled/input.test.ts
+++ b/src/test/dom/props/controlled/input.test.ts
@@ -1,0 +1,224 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { domAdapter } from '../../../../main/dom/index.js';
+import {
+  addControlledInputEventHandlers,
+  isCheckedType,
+  isEventNameIgnored,
+  removeControlledInputEventHandlers,
+  syncControlledInputProps,
+} from '../../../../main/dom/props/controlled/input.js';
+import { createRenderer } from '../../../../main/dom/render.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('isCheckedType', () => {
+  it('returns true for checkbox', () => expect(isCheckedType('checkbox')).toBe(true));
+  it('returns true for radio', () => expect(isCheckedType('radio')).toBe(true));
+  it('returns false for text', () => expect(isCheckedType('text')).toBe(false));
+  it('returns false for empty string', () => expect(isCheckedType('')).toBe(false));
+});
+
+describe('isEventNameIgnored', () => {
+  it('ignores onChange for checkbox', () => {
+    expect(isEventNameIgnored({ type: 'checkbox' }, 'onChange')).toBe(true);
+  });
+  it('does not ignore onInput for checkbox', () => {
+    expect(isEventNameIgnored({ type: 'checkbox' }, 'onInput')).toBe(false);
+  });
+  it('ignores onChange for radio', () => {
+    expect(isEventNameIgnored({ type: 'radio' }, 'onChange')).toBe(true);
+  });
+  it('ignores onInput for text input', () => {
+    expect(isEventNameIgnored({ type: 'text' }, 'onInput')).toBe(true);
+  });
+  it('does not ignore onChange for text input', () => {
+    expect(isEventNameIgnored({ type: 'text' }, 'onChange')).toBe(false);
+  });
+});
+
+describe('addControlledInputEventHandlers / removeControlledInputEventHandlers', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let dom: HTMLInputElement;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    dom = document.createElement('input');
+  });
+
+  it('attaches an input listener for text inputs', () => {
+    const spy = vi.spyOn(dom, 'addEventListener');
+    addControlledInputEventHandlers(dom, runtime);
+    expect(spy).toHaveBeenCalledWith('input', expect.any(Function));
+  });
+
+  it('attaches a change listener for checkboxes', () => {
+    dom.type = 'checkbox';
+    const spy = vi.spyOn(dom, 'addEventListener');
+    addControlledInputEventHandlers(dom, runtime);
+    expect(spy).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('attaches a change listener for radio inputs', () => {
+    dom.type = 'radio';
+    const spy = vi.spyOn(dom, 'addEventListener');
+    addControlledInputEventHandlers(dom, runtime);
+    expect(spy).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('removes the same listener that was added (same reference via WeakMap)', () => {
+    addControlledInputEventHandlers(dom, runtime);
+    const removeSpy = vi.spyOn(dom, 'removeEventListener');
+    removeControlledInputEventHandlers(dom, runtime);
+    expect(removeSpy).toHaveBeenCalledWith('input', expect.any(Function));
+  });
+
+  it('two runtimes get independent handlers', () => {
+    const runtime2 = makeRuntime();
+    const spy1 = vi.spyOn(dom, 'addEventListener');
+    addControlledInputEventHandlers(dom, runtime);
+    const handler1 = spy1.mock.calls[0]![1] as Function;
+    spy1.mockClear();
+    addControlledInputEventHandlers(dom, runtime2);
+    const handler2 = spy1.mock.calls[0]![1] as Function;
+    expect(handler1).not.toBe(handler2);
+  });
+});
+
+describe('syncControlledInputProps', () => {
+  let el: ReturnType<typeof createElement>;
+  let dom: HTMLInputElement;
+
+  beforeEach(() => {
+    dom = document.createElement('input');
+    el = createElement('input');
+    el.reference = dom;
+  });
+
+  it('sets dom.type when it differs from prop', () => {
+    syncControlledInputProps(el, { type: 'email' });
+    expect(dom.getAttribute('type')).toBe('email');
+  });
+
+  it('skips dom.type when already matching', () => {
+    dom.type = 'text';
+    const spy = vi.spyOn(dom, 'setAttribute');
+    syncControlledInputProps(el, { type: 'text' });
+    expect(spy).not.toHaveBeenCalledWith('type', expect.anything());
+  });
+
+  it('sets dom.multiple when prop differs', () => {
+    syncControlledInputProps(el, { multiple: true });
+    expect(dom.multiple).toBe(true);
+  });
+
+  it('sets dom.defaultValue when defaultValue is provided and no value prop', () => {
+    syncControlledInputProps(el, { defaultValue: 'default' });
+    expect(dom.defaultValue).toBe('default');
+  });
+
+  it('does not set defaultValue when value prop is also present', () => {
+    syncControlledInputProps(el, { value: 'v', defaultValue: 'default' });
+    expect(dom.defaultValue).not.toBe('default');
+  });
+
+  it('sets dom.checked for checkbox when checked prop is provided', () => {
+    syncControlledInputProps(el, { type: 'checkbox', checked: true });
+    expect(dom.checked).toBe(true);
+  });
+
+  it('skips dom.checked for checkbox when checked prop is absent', () => {
+    dom.checked = false;
+    syncControlledInputProps(el, { type: 'checkbox' });
+    expect(dom.checked).toBe(false);
+  });
+
+  it('sets dom.value and dom.defaultValue for text when value differs from DOM', () => {
+    dom.value = 'old';
+    syncControlledInputProps(el, { value: 'new' });
+    expect(dom.value).toBe('new');
+    expect(dom.defaultValue).toBe('new');
+  });
+
+  it('skips dom.value assignment when value matches DOM', () => {
+    dom.value = 'same';
+    const descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!;
+    const spy = vi.spyOn(HTMLInputElement.prototype, 'value', 'set');
+    syncControlledInputProps(el, { value: 'same' });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+    void descriptor;
+  });
+});
+
+describe('controlled input event handlers (integration)', () => {
+  let container: HTMLDivElement;
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('input handler: syncs value back to DOM after onInput fires', () => {
+    const onInput = vi.fn();
+    render(createElement('input', { value: 'controlled', onInput }), container);
+    const input = container.querySelector('input')!;
+    input.value = 'user-typed';
+    input.dispatchEvent(new Event('input'));
+    expect(onInput).toHaveBeenCalledOnce();
+    expect(input.value).toBe('controlled');
+  });
+
+  it('input handler: syncs value even when no onInput prop', () => {
+    render(createElement('input', { value: 'fixed' }), container);
+    const input = container.querySelector('input')!;
+    input.value = 'user-typed';
+    input.dispatchEvent(new Event('input'));
+    expect(input.value).toBe('fixed');
+  });
+
+  it('change handler: syncs checked back to DOM after onChange fires for checkbox', () => {
+    const onChange = vi.fn();
+    render(createElement('input', { type: 'checkbox', checked: false, onChange }), container);
+    const input = container.querySelector('input')!;
+    input.checked = true;
+    input.dispatchEvent(new Event('change'));
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(input.checked).toBe(false);
+  });
+
+  it('change handler: syncs checked even when no onChange prop for checkbox', () => {
+    render(createElement('input', { type: 'checkbox', checked: false }), container);
+    const input = container.querySelector('input')!;
+    input.checked = true;
+    input.dispatchEvent(new Event('change'));
+    expect(input.checked).toBe(false);
+  });
+
+  it('input handler: early-returns when target is not in the dom map', () => {
+    render(createElement('input', { value: 'controlled' }), container);
+    const input = container.querySelector('input')!;
+    // Remove element from the map so the handler finds nothing
+    domAdapter.detachElementFromReference(input, runtime);
+    expect(() => input.dispatchEvent(new Event('input'))).not.toThrow();
+  });
+
+  it('change handler: early-returns when target is not in the dom map for checkbox', () => {
+    render(createElement('input', { type: 'checkbox', checked: false }), container);
+    const input = container.querySelector('input')!;
+    domAdapter.detachElementFromReference(input, runtime);
+    expect(() => input.dispatchEvent(new Event('change'))).not.toThrow();
+  });
+});

--- a/src/test/dom/props/controlled/select.test.ts
+++ b/src/test/dom/props/controlled/select.test.ts
@@ -1,0 +1,237 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { domAdapter } from '../../../../main/dom/index.js';
+import {
+  addControlledSelectEventHandlers,
+  isEventNameIgnored,
+  removeControlledSelectEventHandlers,
+  syncControlledSelectProps,
+} from '../../../../main/dom/props/controlled/select.js';
+import { createRenderer } from '../../../../main/dom/render.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('isEventNameIgnored', () => {
+  it('ignores onChange', () => expect(isEventNameIgnored('onChange')).toBe(true));
+  it('does not ignore onInput', () => expect(isEventNameIgnored('onInput')).toBe(false));
+  it('does not ignore onClick', () => expect(isEventNameIgnored('onClick')).toBe(false));
+});
+
+describe('addControlledSelectEventHandlers / removeControlledSelectEventHandlers', () => {
+  it('attaches a change listener', () => {
+    const runtime = makeRuntime();
+    const dom = document.createElement('select');
+    const spy = vi.spyOn(dom, 'addEventListener');
+    addControlledSelectEventHandlers(dom, runtime);
+    expect(spy).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('removes the same listener that was added', () => {
+    const runtime = makeRuntime();
+    const dom = document.createElement('select');
+    addControlledSelectEventHandlers(dom, runtime);
+    const removeSpy = vi.spyOn(dom, 'removeEventListener');
+    removeControlledSelectEventHandlers(dom, runtime);
+    expect(removeSpy).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+});
+
+describe('syncControlledSelectProps', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let container: HTMLDivElement;
+  let render: ReturnType<typeof createRenderer>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  function renderSelect(props: Record<string, any>, options: Array<{ value: string; label: string }>) {
+    const optionEls = options.map(o => createElement('option', { value: o.value }, o.label));
+    render(createElement('select', props, ...optionEls), container);
+    return container.querySelector('select')!;
+  }
+
+  it('sets multiple on DOM element when prop differs', () => {
+    const select = renderSelect({ value: 'a', multiple: true }, [{ value: 'a', label: 'A' }]);
+    const el = runtime.hostAdapter.getElementFromReference(select, runtime)!;
+    syncControlledSelectProps(el, { multiple: true });
+    expect(select.multiple).toBe(true);
+  });
+
+  it('sets selectedIndex to -1 when prop is -1', () => {
+    const select = renderSelect({ value: 'a' }, [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]);
+    const el = runtime.hostAdapter.getElementFromReference(select, runtime)!;
+    syncControlledSelectProps(el, { selectedIndex: -1 });
+    expect(select.selectedIndex).toBe(-1);
+  });
+
+  it('uses selectedIndex option value when selectedIndex > -1', () => {
+    const select = renderSelect({ value: 'b' }, [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]);
+    const el = runtime.hostAdapter.getElementFromReference(select, runtime)!;
+    syncControlledSelectProps(el, { selectedIndex: 0 });
+    expect(select.options[0]!.selected).toBe(true);
+  });
+
+  it('selects the option matching value prop', () => {
+    const select = renderSelect({ value: 'b' }, [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]);
+    const el = runtime.hostAdapter.getElementFromReference(select, runtime)!;
+    syncControlledSelectProps(el, { value: 'b' });
+    expect(select.options[1]!.selected).toBe(true);
+    expect(select.options[0]!.selected).toBe(false);
+  });
+
+  it('selects multiple options when value is an array', () => {
+    const select = renderSelect({ value: ['a', 'c'], multiple: true }, [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+    ]);
+    const el = runtime.hostAdapter.getElementFromReference(select, runtime)!;
+    syncControlledSelectProps(el, { value: ['a', 'c'], multiple: true });
+    expect(select.options[0]!.selected).toBe(true);
+    expect(select.options[1]!.selected).toBe(false);
+    expect(select.options[2]!.selected).toBe(true);
+  });
+
+  it('uses defaultValue on mounting when value is null', () => {
+    const select = renderSelect({}, [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]);
+    const el = runtime.hostAdapter.getElementFromReference(select, runtime)!;
+    syncControlledSelectProps(el, { defaultValue: 'b' }, true);
+    expect(select.options[1]!.selected).toBe(true);
+  });
+
+  it('ignores defaultValue when not mounting', () => {
+    const select = renderSelect({ value: 'a' }, [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]);
+    const el = runtime.hostAdapter.getElementFromReference(select, runtime)!;
+    syncControlledSelectProps(el, { defaultValue: 'b' }, false);
+    expect(select.options[1]!.selected).toBe(false);
+  });
+
+  it('deselects option when value does not match and no selected prop', () => {
+    const select = renderSelect({ value: 'a' }, [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]);
+    const el = runtime.hostAdapter.getElementFromReference(select, runtime)!;
+    syncControlledSelectProps(el, { value: 'a' });
+    expect(select.options[1]!.selected).toBe(false);
+  });
+
+  it('sets option.selected from props.selected when value is null and option has selected prop', () => {
+    const select = renderSelect({ value: 'a' }, [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]);
+    const el = runtime.hostAdapter.getElementFromReference(select, runtime)!;
+    const optionEl = (el.children as any[])[1];
+    optionEl.props = { ...optionEl.props, selected: true };
+    syncControlledSelectProps(el, {});
+    expect(select.options[1]!.selected).toBe(true);
+  });
+
+  it('skips option with no DOM reference', () => {
+    const optionEl = createElement('option', { value: 'x' });
+    const selectEl = createElement('select');
+    selectEl.reference = document.createElement('select');
+    selectEl.children = optionEl;
+    // SIMP_ELEMENT_CHILD_FLAG_ELEMENT = 4 — makes hasElementChild return true so updateOption is reached
+    (selectEl as any).childFlag = 4;
+    expect(() => syncControlledSelectProps(selectEl, { value: 'x' })).not.toThrow();
+  });
+
+  it('updateOption falls back to emptyObject when option has null props', () => {
+    const optionEl = createElement('option');
+    optionEl.props = null;
+    optionEl.reference = document.createElement('option');
+    const selectEl = createElement('select');
+    selectEl.reference = document.createElement('select');
+    selectEl.children = optionEl;
+    (selectEl as any).childFlag = 4;
+    expect(() => syncControlledSelectProps(selectEl, { value: 'x' })).not.toThrow();
+  });
+});
+
+describe('controlled select change handler (integration)', () => {
+  let container: HTMLDivElement;
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('fires onChange and resets selection to match value prop', () => {
+    const onChange = vi.fn();
+    render(
+      createElement(
+        'select',
+        { value: 'a', onChange },
+        createElement('option', { value: 'a' }, 'A'),
+        createElement('option', { value: 'b' }, 'B')
+      ),
+      container
+    );
+    const select = container.querySelector('select')!;
+    select.selectedIndex = 1;
+    select.dispatchEvent(new Event('change'));
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(select.options[0]!.selected).toBe(true);
+  });
+
+  it('syncs selection even without onChange prop', () => {
+    render(
+      createElement(
+        'select',
+        { value: 'a' },
+        createElement('option', { value: 'a' }, 'A'),
+        createElement('option', { value: 'b' }, 'B')
+      ),
+      container
+    );
+    const select = container.querySelector('select')!;
+    select.selectedIndex = 1;
+    select.dispatchEvent(new Event('change'));
+    expect(select.options[0]!.selected).toBe(true);
+  });
+
+  it('change handler: early-returns when target is not in the dom map', () => {
+    render(createElement('select', { value: 'a' }, createElement('option', { value: 'a' }, 'A')), container);
+    const select = container.querySelector('select')!;
+    domAdapter.detachElementFromReference(select, runtime);
+    expect(() => select.dispatchEvent(new Event('change'))).not.toThrow();
+  });
+});

--- a/src/test/dom/props/controlled/textarea.test.ts
+++ b/src/test/dom/props/controlled/textarea.test.ts
@@ -1,0 +1,164 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { domAdapter } from '../../../../main/dom/index.js';
+import {
+  addControlledTextareaEventHandlers,
+  isEventNameIgnored,
+  removeControlledTextareaEventHandlers,
+  syncControlledTextareaProps,
+} from '../../../../main/dom/props/controlled/textarea.js';
+import { createRenderer } from '../../../../main/dom/render.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('isEventNameIgnored', () => {
+  it('ignores onChange', () => expect(isEventNameIgnored('onChange')).toBe(true));
+  it('ignores onInput', () => expect(isEventNameIgnored('onInput')).toBe(true));
+  it('does not ignore onClick', () => expect(isEventNameIgnored('onClick')).toBe(false));
+});
+
+describe('addControlledTextareaEventHandlers / removeControlledTextareaEventHandlers', () => {
+  it('attaches both input and change listeners', () => {
+    const runtime = makeRuntime();
+    const dom = document.createElement('textarea');
+    const spy = vi.spyOn(dom, 'addEventListener');
+    addControlledTextareaEventHandlers(dom, runtime);
+    const events = spy.mock.calls.map(c => c[0]);
+    expect(events).toContain('input');
+    expect(events).toContain('change');
+  });
+
+  it('removes both input and change listeners', () => {
+    const runtime = makeRuntime();
+    const dom = document.createElement('textarea');
+    addControlledTextareaEventHandlers(dom, runtime);
+    const removeSpy = vi.spyOn(dom, 'removeEventListener');
+    removeControlledTextareaEventHandlers(dom, runtime);
+    const events = removeSpy.mock.calls.map(c => c[0]);
+    expect(events).toContain('input');
+    expect(events).toContain('change');
+  });
+});
+
+describe('syncControlledTextareaProps', () => {
+  let dom: HTMLTextAreaElement;
+  let el: ReturnType<typeof createElement>;
+
+  beforeEach(() => {
+    dom = document.createElement('textarea');
+    el = createElement('textarea');
+    el.reference = dom;
+  });
+
+  it('sets value and defaultValue when value prop differs from DOM', () => {
+    dom.value = 'old';
+    syncControlledTextareaProps(el, { value: 'new' });
+    expect(dom.value).toBe('new');
+    expect(dom.defaultValue).toBe('new');
+  });
+
+  it('is a no-op when value matches DOM', () => {
+    dom.value = 'same';
+    const spy = vi.spyOn(HTMLTextAreaElement.prototype, 'value', 'set');
+    syncControlledTextareaProps(el, { value: 'same' });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('sets defaultValue on mounting when value is null and defaultValue provided', () => {
+    syncControlledTextareaProps(el, { defaultValue: 'init' }, true);
+    expect(dom.value).toBe('init');
+    expect(dom.defaultValue).toBe('init');
+  });
+
+  it('is a no-op when value is null and not mounting', () => {
+    dom.value = 'existing';
+    syncControlledTextareaProps(el, {}, false);
+    expect(dom.value).toBe('existing');
+  });
+
+  it('is a no-op when value is null, mounting, and defaultValue is null', () => {
+    syncControlledTextareaProps(el, {}, true);
+    expect(dom.value).toBe('');
+  });
+
+  it('is a no-op when value is null, mounting, and defaultValue matches DOM', () => {
+    dom.defaultValue = 'same';
+    dom.value = 'same';
+    const spy = vi.spyOn(HTMLTextAreaElement.prototype, 'value', 'set');
+    syncControlledTextareaProps(el, { defaultValue: 'same' }, true);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('controlled textarea event handlers (integration)', () => {
+  let container: HTMLDivElement;
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('input handler: syncs value after onInput fires', () => {
+    const onInput = vi.fn();
+    render(createElement('textarea', { value: 'controlled', onInput }), container);
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'user-typed';
+    textarea.dispatchEvent(new Event('input'));
+    expect(onInput).toHaveBeenCalledOnce();
+    expect(textarea.value).toBe('controlled');
+  });
+
+  it('input handler: syncs value even without onInput prop', () => {
+    render(createElement('textarea', { value: 'fixed' }), container);
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'user-typed';
+    textarea.dispatchEvent(new Event('input'));
+    expect(textarea.value).toBe('fixed');
+  });
+
+  it('change handler: syncs value after onChange fires', () => {
+    const onChange = vi.fn();
+    render(createElement('textarea', { value: 'controlled', onChange }), container);
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'user-typed';
+    textarea.dispatchEvent(new Event('change'));
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(textarea.value).toBe('controlled');
+  });
+
+  it('change handler: syncs value without onChange prop', () => {
+    render(createElement('textarea', { value: 'fixed' }), container);
+    const textarea = container.querySelector('textarea')!;
+    textarea.value = 'user-typed';
+    textarea.dispatchEvent(new Event('change'));
+    expect(textarea.value).toBe('fixed');
+  });
+
+  it('input handler: early-returns when target is not in the dom map', () => {
+    render(createElement('textarea', { value: 'controlled' }), container);
+    const textarea = container.querySelector('textarea')!;
+    domAdapter.detachElementFromReference(textarea, runtime);
+    expect(() => textarea.dispatchEvent(new Event('input'))).not.toThrow();
+  });
+
+  it('change handler: early-returns when target is not in the dom map', () => {
+    render(createElement('textarea', { value: 'controlled' }), container);
+    const textarea = container.querySelector('textarea')!;
+    domAdapter.detachElementFromReference(textarea, runtime);
+    expect(() => textarea.dispatchEvent(new Event('change'))).not.toThrow();
+  });
+});

--- a/src/test/dom/props/dangerInnerHTML.test.ts
+++ b/src/test/dom/props/dangerInnerHTML.test.ts
@@ -1,0 +1,65 @@
+import { createElement } from '@simpreact/internal';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { patchDangerInnerHTML } from '../../../main/dom/props/dangerInnerHTML.js';
+
+describe('patchDangerInnerHTML', () => {
+  let dom: HTMLDivElement;
+
+  beforeEach(() => {
+    dom = document.createElement('div');
+  });
+
+  it('sets innerHTML when transitioning from null to a value', () => {
+    patchDangerInnerHTML(null, { __html: '<b>hello</b>' }, createElement('div'), dom);
+    expect(dom.innerHTML).toBe('<b>hello</b>');
+  });
+
+  it('updates innerHTML when the value changes', () => {
+    dom.innerHTML = '<b>old</b>';
+    patchDangerInnerHTML({ __html: '<b>old</b>' }, { __html: '<i>new</i>' }, createElement('div'), dom);
+    expect(dom.innerHTML).toBe('<i>new</i>');
+  });
+
+  it('clears innerHTML when next value is null', () => {
+    dom.innerHTML = '<b>old</b>';
+    patchDangerInnerHTML({ __html: '<b>old</b>' }, null, createElement('div'), dom);
+    expect(dom.innerHTML).toBe('');
+  });
+
+  it('clears innerHTML when next value is undefined', () => {
+    dom.innerHTML = '<b>old</b>';
+    patchDangerInnerHTML({ __html: '<b>old</b>' }, undefined, createElement('div'), dom);
+    expect(dom.innerHTML).toBe('');
+  });
+
+  it('is a no-op when prevHTML and nextHTML are identical strings', () => {
+    dom.innerHTML = '<b>hello</b>';
+    const spy = vi.spyOn(dom, 'innerHTML', 'set');
+    patchDangerInnerHTML({ __html: '<b>hello</b>' }, { __html: '<b>hello</b>' }, createElement('div'), dom);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('skips DOM write when parsed content is already identical', () => {
+    dom.innerHTML = '<b>hello</b>';
+    // prevHTML (undefined) !== nextHTML so the early-return doesn't apply,
+    // but isSameInnerHTML returns true — DOM must remain unchanged.
+    patchDangerInnerHTML(null, { __html: '<b>hello</b>' }, createElement('div'), dom);
+    expect(dom.firstChild).not.toBeNull();
+    expect(dom.innerHTML).toBe('<b>hello</b>');
+  });
+
+  it('emits a console.warn when element has SimpElement children alongside dangerouslySetInnerHTML', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const el = createElement('div', null, createElement('span'));
+    // createElement stores SimpElement children in el.children, making it truthy
+    patchDangerInnerHTML(null, { __html: '<b>hello</b>' }, el, dom);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]![0]).toMatch(/dangerouslySetInnerHTML/);
+  });
+
+  it('does not warn when element has no children', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    patchDangerInnerHTML(null, { __html: '<b>hello</b>' }, createElement('div'), dom);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/dom/props/props.test.ts
+++ b/src/test/dom/props/props.test.ts
@@ -1,0 +1,440 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { domAdapter } from '../../../main/dom/index.js';
+import { mountProps, patchProps, unmountProps } from '../../../main/dom/props/props.js';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const HTML_NS = 'http://www.w3.org/1999/xhtml';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+// ---------------------------------------------------------------------------
+// mountProps — regular elements
+// ---------------------------------------------------------------------------
+
+describe('mountProps — regular elements', () => {
+  let dom: HTMLDivElement;
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    dom = document.createElement('div');
+    runtime = makeRuntime();
+    vi.spyOn(document, 'addEventListener');
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('sets a data-* attribute via setAttribute', () => {
+    const el = createElement('div', { 'data-id': '42' });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.getAttribute('data-id')).toBe('42');
+  });
+
+  it('sets boolean prop disabled as a DOM property', () => {
+    const el = createElement('div', { disabled: true });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect((dom as any).disabled).toBe(true);
+  });
+
+  it('sets hidden as a DOM property', () => {
+    const el = createElement('div', { hidden: true });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect((dom as any).hidden).toBe(true);
+  });
+
+  it('sets autoFocus as dom.autofocus', () => {
+    const el = createElement('div', { autoFocus: true });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect((dom as any).autofocus).toBe(true);
+  });
+
+  it('sets volume as a DOM property', () => {
+    const video = document.createElement('video') as any;
+    const el = createElement('video', { volume: 0.5 });
+    mountProps(video, el, HTML_NS, runtime);
+    expect(video.volume).toBe(0.5);
+  });
+
+  it('skips children, className, key, ref props', () => {
+    const el = createElement('div', { children: 'x', className: 'c', key: 'k', ref: {} });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.getAttribute('children')).toBeNull();
+    expect(dom.getAttribute('className')).toBeNull();
+    expect(dom.getAttribute('key')).toBeNull();
+    expect(dom.getAttribute('ref')).toBeNull();
+  });
+
+  it('delegates style to patchStyle', () => {
+    const el = createElement('div', { style: { color: 'red' } });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.style.color).toBe('red');
+  });
+
+  it('delegates dangerouslySetInnerHTML to patchDangerInnerHTML', () => {
+    const el = createElement('div', { dangerouslySetInnerHTML: { __html: '<b>hi</b>' } });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.innerHTML).toBe('<b>hi</b>');
+  });
+
+  it('registers a delegated event handler via patchEvent', () => {
+    const handler = vi.fn();
+    const el = createElement('div', { onClick: handler });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(document.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+  });
+
+  it('sets allowfullscreen as a DOM property (boolean case in patchDefaultElementPropAndAttrs)', () => {
+    const video = document.createElement('div') as any;
+    const el = createElement('div', { allowfullscreen: true });
+    mountProps(video, el, HTML_NS, runtime);
+    expect(video.allowfullscreen).toBe(true);
+  });
+
+  it('sets xlink:href via setAttributeNS in SVG context', () => {
+    const svgDom = document.createElementNS(SVG_NS, 'use') as unknown as HTMLElement;
+    const el = createElement('use', { 'xlink:href': '#icon' });
+    mountProps(svgDom, el, SVG_NS, runtime);
+    // getAttributeNS takes the local name (no prefix)
+    expect(svgDom.getAttributeNS('http://www.w3.org/1999/xlink', 'href')).toBe('#icon');
+  });
+
+  it('sets xml:lang via setAttributeNS', () => {
+    const svgDom = document.createElementNS(SVG_NS, 'svg') as unknown as HTMLElement;
+    const el = createElement('svg', { 'xml:lang': 'en' });
+    mountProps(svgDom, el, SVG_NS, runtime);
+    expect(svgDom.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang')).toBe('en');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mountProps — form elements (uncontrolled)
+// ---------------------------------------------------------------------------
+
+describe('mountProps — form elements, uncontrolled', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+  });
+
+  it('sets value DOM prop for uncontrolled input', () => {
+    const dom = document.createElement('input') as any;
+    const el = createElement('input', { defaultValue: 'init' });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.defaultValue).toBe('init');
+  });
+
+  it('sets multiple as DOM prop', () => {
+    const dom = document.createElement('select') as any;
+    const el = createElement('select', { multiple: true });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.multiple).toBe(true);
+  });
+
+  it('sets defaultChecked as DOM property', () => {
+    const dom = document.createElement('input') as any;
+    const el = createElement('input', { type: 'checkbox', defaultChecked: true });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.defaultChecked).toBe(true);
+  });
+
+  it('sets readOnly as a boolean DOM property on form element', () => {
+    const dom = document.createElement('input') as any;
+    const el = createElement('input', { readOnly: true });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.readOnly).toBe(true);
+  });
+
+  it('sets required as a boolean DOM property on form element', () => {
+    const dom = document.createElement('input') as any;
+    const el = createElement('input', { required: true });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.required).toBe(true);
+  });
+
+  it('sets capture as a boolean DOM property on form element', () => {
+    const dom = document.createElement('input') as any;
+    const el = createElement('input', { capture: true });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.capture).toBe(true);
+  });
+
+  it('sets a generic attribute (name) on a form element via setAttribute', () => {
+    const dom = document.createElement('input');
+    const el = createElement('input', { name: 'username' });
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.getAttribute('name')).toBe('username');
+  });
+
+  it('does not add controlled event handlers when uncontrolled', () => {
+    const dom = document.createElement('input');
+    const el = createElement('input', { defaultValue: 'x' });
+    const spy = vi.spyOn(dom, 'addEventListener');
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mountProps — form elements (controlled)
+// ---------------------------------------------------------------------------
+
+describe('mountProps — form elements, controlled', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+  });
+
+  it('adds controlled event handlers when value prop is present', () => {
+    const dom = document.createElement('input');
+    const el = createElement('input', { value: 'controlled' });
+    el.reference = dom;
+    const spy = vi.spyOn(dom, 'addEventListener');
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('syncs value on mount for controlled input', () => {
+    const dom = document.createElement('input') as any;
+    const el = createElement('input', { value: 'hello' });
+    el.reference = dom;
+    mountProps(dom, el, HTML_NS, runtime);
+    expect(dom.value).toBe('hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchProps — regular elements
+// ---------------------------------------------------------------------------
+
+describe('patchProps — regular elements', () => {
+  let dom: HTMLDivElement;
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    dom = document.createElement('div');
+    runtime = makeRuntime();
+    vi.spyOn(document, 'addEventListener');
+    vi.spyOn(document, 'removeEventListener');
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('updates a changed attribute', () => {
+    const prev = createElement('div', { 'data-x': 'old' });
+    const next = createElement('div', { 'data-x': 'new' });
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.getAttribute('data-x')).toBe('new');
+  });
+
+  it('removes an attribute when next value is null', () => {
+    dom.setAttribute('data-x', 'old');
+    const prev = createElement('div', { 'data-x': 'old' });
+    const next = createElement('div', {});
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.getAttribute('data-x')).toBeNull();
+  });
+
+  it('adds a new attribute not in prevProps', () => {
+    const prev = createElement('div', {});
+    const next = createElement('div', { 'data-new': 'yes' });
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.getAttribute('data-new')).toBe('yes');
+  });
+
+  it('skips unchanged props', () => {
+    dom.setAttribute('data-x', 'same');
+    const prev = createElement('div', { 'data-x': 'same' });
+    const next = createElement('div', { 'data-x': 'same' });
+    const spy = vi.spyOn(dom, 'setAttribute');
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('handles null prevElement.props by treating it as empty (|| emptyObject branch)', () => {
+    const prev = createElement('div');
+    prev.props = null;
+    const next = createElement('div', { 'data-x': 'added' });
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.getAttribute('data-x')).toBe('added');
+  });
+
+  it('handles null nextElement.props by treating it as empty (|| emptyObject branch)', () => {
+    dom.setAttribute('data-x', 'old');
+    const prev = createElement('div', { 'data-x': 'old' });
+    const next = createElement('div');
+    next.props = null;
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.getAttribute('data-x')).toBeNull();
+  });
+
+  it('delegated event: function→function keeps the same document listener (count unchanged)', () => {
+    const oldHandler = vi.fn();
+    const newHandler = vi.fn();
+    const prev = createElement('div', { onClick: oldHandler });
+    const next = createElement('div', { onClick: newHandler });
+    // Register the initial listener so count = 1
+    mountProps(dom, prev, HTML_NS, runtime);
+    vi.mocked(document.addEventListener).mockClear();
+    vi.mocked(document.removeEventListener).mockClear();
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    // Delegated events read the handler from element.props at dispatch time,
+    // so no document listener change is needed when replacing function→function.
+    expect(document.addEventListener).not.toHaveBeenCalled();
+    expect(document.removeEventListener).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchProps — form elements
+// ---------------------------------------------------------------------------
+
+describe('patchProps — form elements', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+  });
+
+  it('transitions uncontrolled → controlled: adds event handlers', () => {
+    const dom = document.createElement('input');
+    const prev = createElement('input', { defaultValue: 'x' });
+    const next = createElement('input', { value: 'controlled' });
+    next.reference = dom;
+    const spy = vi.spyOn(dom, 'addEventListener');
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('transitions controlled → uncontrolled: removes event handlers', () => {
+    const dom = document.createElement('input');
+    const prev = createElement('input', { value: 'controlled' });
+    const next = createElement('input', { defaultValue: 'x' });
+    prev.reference = dom;
+    // Add handlers first
+    dom.addEventListener('input', () => {});
+    const spy = vi.spyOn(dom, 'removeEventListener');
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('syncs controlled props when remaining controlled', () => {
+    const dom = document.createElement('input') as any;
+    const prev = createElement('input', { value: 'old' });
+    const next = createElement('input', { value: 'new' });
+    next.reference = dom;
+    prev.reference = dom;
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.value).toBe('new');
+  });
+
+  it('ignored event props (e.g. onInput for checkbox) are suppressed', () => {
+    const dom = document.createElement('input');
+    const handler = vi.fn();
+    const prev = createElement('input', { type: 'checkbox', checked: false, onInput: handler });
+    const next = createElement('input', { type: 'checkbox', checked: true, onInput: handler });
+    prev.reference = dom;
+    next.reference = dom;
+    const addSpy = vi.spyOn(dom, 'addEventListener');
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    const inputCalls = addSpy.mock.calls.filter(c => c[0] === 'input');
+    expect(inputCalls.length).toBe(0);
+  });
+
+  it('skips className and similar skipped props on form elements (no-op)', () => {
+    const dom = document.createElement('input');
+    const prev = createElement('input', { className: 'old' });
+    const next = createElement('input', { className: 'new' });
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.className).toBe('');
+  });
+
+  it('skips children prop on form elements (case children: branch)', () => {
+    const dom = document.createElement('input');
+    const prev = createElement('input', { children: 'a' as any });
+    const next = createElement('input', { children: 'b' as any });
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.textContent).toBe('');
+  });
+
+  it('patches value to empty string when next element has an explicit null value prop (uncontrolled)', () => {
+    const dom = document.createElement('input') as any;
+    dom.value = 'old';
+    const prev = createElement('input', { defaultValue: 'old' });
+    const next = createElement('input', { value: null as any });
+    next.reference = dom;
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.value).toBe('');
+  });
+
+  it('patches style on a form element', () => {
+    const dom = document.createElement('input');
+    const prev = createElement('input', { style: { color: 'red' } });
+    const next = createElement('input', { style: { color: 'blue' } });
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    expect(dom.style.color).toBe('blue');
+  });
+
+  it('patches non-ignored event handler on a controlled form element', () => {
+    const dom = document.createElement('input');
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    const prev = createElement('input', { value: 'x', onClick: handler1 });
+    const next = createElement('input', { value: 'x', onClick: handler2 });
+    prev.reference = dom;
+    next.reference = dom;
+    mountProps(dom, prev, HTML_NS, runtime);
+    addSpy.mockClear();
+    patchProps(dom, prev, next, HTML_NS, runtime);
+    // onClick is not ignored for controlled inputs; delegated function→function keeps same listener
+    expect(addSpy).not.toHaveBeenCalled();
+    addSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unmountProps
+// ---------------------------------------------------------------------------
+
+describe('unmountProps', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    vi.spyOn(document, 'addEventListener');
+    vi.spyOn(document, 'removeEventListener');
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('is a no-op when element.props is null', () => {
+    const dom = document.createElement('div');
+    const el = createElement('div');
+    el.props = null;
+    expect(() => unmountProps(dom, el, runtime)).not.toThrow();
+  });
+
+  it('removes delegated event listener when onClick was set', () => {
+    const dom = document.createElement('div');
+    const el = createElement('div', { onClick: vi.fn() });
+    // Add first so count > 0
+    mountProps(dom, el, HTML_NS, runtime);
+    unmountProps(dom, el, runtime);
+    expect(document.removeEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+  });
+
+  it('removes controlled form element handlers on unmount', () => {
+    const dom = document.createElement('input');
+    const el = createElement('input', { value: 'x' });
+    el.reference = dom;
+    mountProps(dom, el, HTML_NS, runtime);
+    const spy = vi.spyOn(dom, 'removeEventListener');
+    unmountProps(dom, el, runtime);
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/test/dom/props/style.test.ts
+++ b/src/test/dom/props/style.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { patchStyle } from '../../../main/dom/props/style.js';
+
+describe('patchStyle', () => {
+  let dom: HTMLDivElement;
+
+  beforeEach(() => {
+    dom = document.createElement('div');
+  });
+
+  describe('null / undefined next value', () => {
+    it('removes the style attribute when next is null', () => {
+      dom.setAttribute('style', 'color: red');
+      patchStyle(null, null, dom);
+      expect(dom.getAttribute('style')).toBeNull();
+    });
+
+    it('removes the style attribute when next is undefined', () => {
+      dom.setAttribute('style', 'color: red');
+      patchStyle(null, undefined, dom);
+      expect(dom.getAttribute('style')).toBeNull();
+    });
+  });
+
+  describe('string next value', () => {
+    it('assigns cssText directly', () => {
+      patchStyle(null, 'color: red; font-size: 16px', dom);
+      expect(dom.style.color).toBe('red');
+      expect(dom.style.fontSize).toBe('16px');
+    });
+
+    it('replaces existing cssText', () => {
+      dom.style.cssText = 'color: red';
+      patchStyle('color: red', 'color: blue', dom);
+      expect(dom.style.color).toBe('blue');
+    });
+  });
+
+  describe('object next value, no previous', () => {
+    it('sets all properties via setProperty', () => {
+      patchStyle(null, { backgroundColor: 'red', fontSize: '16px' }, dom);
+      expect(dom.style.getPropertyValue('background-color')).toBe('red');
+      expect(dom.style.getPropertyValue('font-size')).toBe('16px');
+    });
+
+    it('converts camelCase to kebab-case', () => {
+      patchStyle(null, { borderTopColor: 'green' }, dom);
+      expect(dom.style.getPropertyValue('border-top-color')).toBe('green');
+    });
+
+    it('handles multiple uppercase letters', () => {
+      patchStyle(null, { marginBlockStart: '4px' }, dom);
+      expect(dom.style.getPropertyValue('margin-block-start')).toBe('4px');
+    });
+  });
+
+  describe('object next value, object previous', () => {
+    it('updates only changed properties', () => {
+      const setProperty = vi.spyOn(dom.style, 'setProperty');
+      patchStyle({ color: 'red', fontSize: '16px' }, { color: 'blue', fontSize: '16px' }, dom);
+      const calls = setProperty.mock.calls.map(c => c[0]);
+      expect(calls).toContain('color');
+      expect(calls).not.toContain('font-size');
+    });
+
+    it('removes properties absent in next', () => {
+      dom.style.setProperty('font-size', '16px');
+      patchStyle({ color: 'red', fontSize: '16px' }, { color: 'red' }, dom);
+      expect(dom.style.getPropertyValue('font-size')).toBe('');
+    });
+
+    it('does not call setProperty for identical values', () => {
+      dom.style.setProperty('color', 'red');
+      const spy = vi.spyOn(dom.style, 'setProperty');
+      patchStyle({ color: 'red' }, { color: 'red' }, dom);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('object next value, string previous (treated as no-prev)', () => {
+    it('sets all properties from next object', () => {
+      dom.style.cssText = 'color: red';
+      patchStyle('color: red', { backgroundColor: 'blue' }, dom);
+      expect(dom.style.getPropertyValue('background-color')).toBe('blue');
+    });
+  });
+});

--- a/src/test/dom/render.test.ts
+++ b/src/test/dom/render.test.ts
@@ -1,0 +1,213 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { domAdapter } from '../../main/dom/index.js';
+import { createCreateRoot, createRenderer } from '../../main/dom/render.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('createRenderer', () => {
+  let container: HTMLDivElement;
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  // -------------------------------------------------------------------------
+  // Early returns
+  // -------------------------------------------------------------------------
+
+  describe('null container', () => {
+    it('is a no-op when container is null', () => {
+      expect(() => render(createElement('div'), null)).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // First mount
+  // -------------------------------------------------------------------------
+
+  describe('initial mount', () => {
+    it('appends a HOST element into the container', () => {
+      render(createElement('div'), container);
+      expect(container.querySelector('div')).not.toBeNull();
+    });
+
+    it('renders text children', () => {
+      render(createElement('p', null, 'hello'), container);
+      expect(container.querySelector('p')!.textContent).toBe('hello');
+    });
+
+    it('renders nested HOST children', () => {
+      render(createElement('div', null, createElement('span', null, 'child')), container);
+      expect(container.querySelector('div > span')!.textContent).toBe('child');
+    });
+
+    it('renders an FC component', () => {
+      const Comp = ({ label }: any) => createElement('b', null, label);
+      render(createElement(Comp, { label: 'hi' }), container);
+      expect(container.querySelector('b')!.textContent).toBe('hi');
+    });
+
+    it('sets className on mounted element', () => {
+      render(createElement('div', { className: 'box' }), container);
+      expect(container.querySelector('div')!.className).toBe('box');
+    });
+
+    it('clears existing container content before mounting', () => {
+      container.innerHTML = '<span>stale</span>';
+      render(createElement('div'), container);
+      expect(container.querySelector('span')).toBeNull();
+      expect(container.querySelector('div')).not.toBeNull();
+    });
+
+    it('does nothing when element is null and nothing is mounted', () => {
+      expect(() => render(null, container)).not.toThrow();
+      expect(container.childNodes.length).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Patch (second render into same container)
+  // -------------------------------------------------------------------------
+
+  describe('patch (subsequent render)', () => {
+    it('patches text content in place', () => {
+      render(createElement('p', null, 'before'), container);
+      const p = container.querySelector('p')!;
+      render(createElement('p', null, 'after'), container);
+      expect(container.querySelector('p')).toBe(p);
+      expect(p.textContent).toBe('after');
+    });
+
+    it('patches className', () => {
+      render(createElement('div', { className: 'a' }), container);
+      render(createElement('div', { className: 'b' }), container);
+      expect(container.querySelector('div')!.className).toBe('b');
+    });
+
+    it('patches an attribute change', () => {
+      render(createElement('div', { 'data-x': 'old' }), container);
+      render(createElement('div', { 'data-x': 'new' }), container);
+      expect(container.querySelector('div')!.getAttribute('data-x')).toBe('new');
+    });
+
+    it('replaces element when type changes', () => {
+      render(createElement('div'), container);
+      const oldDiv = container.querySelector('div');
+      render(createElement('span'), container);
+      expect(container.querySelector('div')).toBeNull();
+      expect(container.querySelector('span')).not.toBeNull();
+      expect(container.querySelector('span')).not.toBe(oldDiv);
+    });
+
+    it('patches an FC component output', () => {
+      const Comp = ({ label }: any) => createElement('b', null, label);
+      render(createElement(Comp, { label: 'v1' }), container);
+      render(createElement(Comp, { label: 'v2' }), container);
+      expect(container.querySelector('b')!.textContent).toBe('v2');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unmount
+  // -------------------------------------------------------------------------
+
+  describe('unmount (render null)', () => {
+    it('removes the mounted element from the container', () => {
+      render(createElement('div'), container);
+      render(null, container);
+      expect(container.querySelector('div')).toBeNull();
+      expect(container.childNodes.length).toBe(0);
+    });
+
+    it('removes FC component and all its children', () => {
+      const Comp = () => createElement('div', null, createElement('span'));
+      render(createElement(Comp, {}), container);
+      render(null, container);
+      expect(container.querySelector('div')).toBeNull();
+    });
+
+    it('clears the container reference so a subsequent mount works', () => {
+      render(createElement('div'), container);
+      render(null, container);
+      render(createElement('p'), container);
+      expect(container.querySelector('p')).not.toBeNull();
+      expect(container.querySelector('div')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SVG namespace — covers the non-null branch of getHostNamespaces()?.self
+  // -------------------------------------------------------------------------
+
+  describe('SVG namespace', () => {
+    it('mounts an <svg> element using the SVG namespace', () => {
+      render(createElement('svg'), container);
+      const svg = container.querySelector('svg')!;
+      expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    });
+
+    it('patches an <svg> element without error', () => {
+      render(createElement('svg', { 'data-v': '1' }), container);
+      render(createElement('svg', { 'data-v': '2' }), container);
+      expect(container.querySelector('svg')!.getAttribute('data-v')).toBe('2');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCreateRoot
+// ---------------------------------------------------------------------------
+
+describe('createCreateRoot', () => {
+  let container: HTMLDivElement;
+  let runtime: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('root.render() mounts an element', () => {
+    const root = createCreateRoot(runtime)(container);
+    root.render(createElement('div'));
+    expect(container.querySelector('div')).not.toBeNull();
+    root.unmount();
+  });
+
+  it('second root.render() patches in place', () => {
+    const root = createCreateRoot(runtime)(container);
+    root.render(createElement('p', null, 'v1'));
+    const p = container.querySelector('p')!;
+    root.render(createElement('p', null, 'v2'));
+    expect(container.querySelector('p')).toBe(p);
+    expect(p.textContent).toBe('v2');
+    root.unmount();
+  });
+
+  it('root.unmount() removes all mounted content', () => {
+    const root = createCreateRoot(runtime)(container);
+    root.render(createElement('div'));
+    root.unmount();
+    expect(container.querySelector('div')).toBeNull();
+    expect(container.childNodes.length).toBe(0);
+  });
+});

--- a/src/test/hooks/areDepsEqual.test.ts
+++ b/src/test/hooks/areDepsEqual.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { areDepsEqual } from '../../main/hooks/index.js';
+
+describe('areDepsEqual', () => {
+  it('returns true when both dep lists are undefined', () => {
+    expect(areDepsEqual(undefined, undefined)).toBe(true);
+  });
+
+  it('returns false when left side is undefined and right is an array', () => {
+    expect(areDepsEqual(undefined, [1])).toBe(false);
+  });
+
+  it('returns false when left side is an array and right is undefined', () => {
+    expect(areDepsEqual([1], undefined)).toBe(false);
+  });
+
+  it('returns true for empty arrays', () => {
+    expect(areDepsEqual([], [])).toBe(true);
+  });
+
+  it('returns true for arrays with identical primitive values', () => {
+    expect(areDepsEqual([1, 'a', true], [1, 'a', true])).toBe(true);
+  });
+
+  it('returns false when values differ', () => {
+    expect(areDepsEqual([1], [2])).toBe(false);
+  });
+
+  it('returns false for arrays of different lengths', () => {
+    expect(areDepsEqual([1, 2], [1])).toBe(false);
+  });
+
+  it('uses reference equality for objects', () => {
+    const obj = {};
+    expect(areDepsEqual([obj], [obj])).toBe(true);
+    expect(areDepsEqual([{}], [{}])).toBe(false);
+  });
+});

--- a/src/test/hooks/createUseCatch.test.ts
+++ b/src/test/hooks/createUseCatch.test.ts
@@ -1,0 +1,110 @@
+import { createElement, createRenderRuntime } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { domAdapter } from '../../main/dom/index.js';
+import { createRenderer } from '../../main/dom/render.js';
+import { createUseCatch } from '../../main/hooks/index.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('createUseCatch', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+  let container: HTMLDivElement;
+  let useCatch: ReturnType<typeof createUseCatch>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    useCatch = createUseCatch(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('handler is called when a direct child FC throws during render', () => {
+    const handler = vi.fn();
+    const Thrower = () => {
+      throw new Error('child error');
+    };
+    const Parent = () => {
+      useCatch(handler);
+      return createElement(Thrower, {});
+    };
+    expect(() => render(createElement(Parent, {}), container)).not.toThrow();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0]![0].message).toBe('child error');
+  });
+
+  it('all handlers registered in the same component receive the error', () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    const Thrower = () => {
+      throw new Error('multi');
+    };
+    const Parent = () => {
+      useCatch(handler1);
+      useCatch(handler2);
+      return createElement(Thrower, {});
+    };
+    render(createElement(Parent, {}), container);
+    expect(handler1).toHaveBeenCalledOnce();
+    expect(handler2).toHaveBeenCalledOnce();
+  });
+
+  it('catches error when Thrower is nested inside a HOST element (walks past non-FC parent)', () => {
+    const handler = vi.fn();
+    const Thrower = () => {
+      throw new Error('nested');
+    };
+    const Parent = () => {
+      useCatch(handler);
+      // HOST element sits between Parent and Thrower in the parent chain
+      return createElement('div', null, createElement(Thrower, {}));
+    };
+    render(createElement(Parent, {}), container);
+    expect(handler).toHaveBeenCalledWith(expect.any(Error));
+    expect(handler.mock.calls[0]![0].message).toBe('nested');
+  });
+
+  it('propagates to grandparent when intermediate FC has no catcher', () => {
+    const grandparentHandler = vi.fn();
+    const Thrower = () => {
+      throw new Error('propagate');
+    };
+    const Child = () => createElement(Thrower, {});
+    const Parent = () => createElement(Child, {}); // no useCatch
+    const Grandparent = () => {
+      useCatch(grandparentHandler);
+      return createElement(Parent, {});
+    };
+    render(createElement(Grandparent, {}), container);
+    expect(grandparentHandler).toHaveBeenCalledWith(expect.any(Error));
+    expect(grandparentHandler.mock.calls[0]![0].message).toBe('propagate');
+  });
+
+  it('when handler itself throws, the thrown error propagates to the grandparent catcher', () => {
+    const grandparentHandler = vi.fn();
+    const Thrower = () => {
+      throw new Error('original');
+    };
+    const Parent = () => {
+      useCatch(() => {
+        throw new Error('rethrown');
+      });
+      return createElement(Thrower, {});
+    };
+    const Grandparent = () => {
+      useCatch(grandparentHandler);
+      return createElement(Parent, {});
+    };
+    render(createElement(Grandparent, {}), container);
+    expect(grandparentHandler).toHaveBeenCalledWith(expect.any(Error));
+    expect(grandparentHandler.mock.calls[0]![0].message).toBe('rethrown');
+  });
+});

--- a/src/test/hooks/createUseEffect.test.ts
+++ b/src/test/hooks/createUseEffect.test.ts
@@ -1,0 +1,147 @@
+import { createElement, createRenderRuntime, withSyncRerender } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { domAdapter } from '../../main/dom/index.js';
+import { createRenderer } from '../../main/dom/render.js';
+import { createUseEffect, createUseState } from '../../main/hooks/index.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('createUseEffect', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+  let container: HTMLDivElement;
+  let useEffect: ReturnType<typeof createUseEffect>;
+  let useState: ReturnType<typeof createUseState>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    useEffect = createUseEffect(runtime);
+    useState = createUseState(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('effect runs synchronously after initial mount', () => {
+    const effect = vi.fn();
+    const Comp = () => {
+      useEffect(effect, []);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(effect).toHaveBeenCalledOnce();
+  });
+
+  it('effect with empty deps [] does not re-run on re-render', () => {
+    const effect = vi.fn();
+    let dispatch: any;
+    const Comp = () => {
+      const [, set] = useState(0);
+      dispatch = set;
+      useEffect(effect, []);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(runtime, () => dispatch(1));
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it('effect re-runs when a dep value changes', () => {
+    const effect = vi.fn();
+    let dispatch: any;
+    const Comp = () => {
+      const [count, set] = useState(0);
+      dispatch = set;
+      useEffect(effect, [count]);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    withSyncRerender(runtime, () => dispatch(1));
+    expect(effect).toHaveBeenCalledTimes(2);
+
+    withSyncRerender(runtime, () => dispatch(1)); // same value — no re-run
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+
+  it('effect with no deps re-runs on every render', () => {
+    const effect = vi.fn();
+    let dispatch: any;
+    const Comp = () => {
+      const [, set] = useState(0);
+      dispatch = set;
+      useEffect(effect);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(runtime, () => dispatch(1));
+    withSyncRerender(runtime, () => dispatch(2));
+    expect(effect).toHaveBeenCalledTimes(3);
+  });
+
+  it('cleanup function runs before the next effect call', () => {
+    const order: string[] = [];
+    let dispatch: any;
+    const Comp = () => {
+      const [count, set] = useState(0);
+      dispatch = set;
+      useEffect(() => {
+        order.push(`effect:${count}`);
+        return () => order.push(`cleanup:${count}`);
+      }, [count]);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(order).toEqual(['effect:0']);
+
+    withSyncRerender(runtime, () => dispatch(1));
+    expect(order).toEqual(['effect:0', 'cleanup:0', 'effect:1']);
+  });
+
+  it('cleanup runs on unmount', () => {
+    const cleanup = vi.fn();
+    const Comp = () => {
+      useEffect(() => cleanup, []);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    render(null, container);
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it('no cleanup (effect returns undefined) does not throw on unmount', () => {
+    const Comp = () => {
+      useEffect(() => {}, []);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(() => render(null, container)).not.toThrow();
+  });
+
+  it('multiple effects in one component run in declaration order', () => {
+    const calls: number[] = [];
+    const Comp = () => {
+      useEffect(() => {
+        calls.push(1);
+      }, []);
+      useEffect(() => {
+        calls.push(2);
+      }, []);
+      useEffect(() => {
+        calls.push(3);
+      }, []);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(calls).toEqual([1, 2, 3]);
+  });
+});

--- a/src/test/hooks/createUseRef.test.ts
+++ b/src/test/hooks/createUseRef.test.ts
@@ -1,0 +1,82 @@
+import { createElement, createRenderRuntime, withSyncRerender } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { domAdapter } from '../../main/dom/index.js';
+import { createRenderer } from '../../main/dom/render.js';
+import { createUseRef, createUseState } from '../../main/hooks/index.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('createUseRef', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+  let container: HTMLDivElement;
+  let useRef: ReturnType<typeof createUseRef>;
+  let useState: ReturnType<typeof createUseState>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    useRef = createUseRef(runtime);
+    useState = createUseState(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('returns an object with the given initial value', () => {
+    let ref: any;
+    const Comp = () => {
+      ref = useRef(42);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(ref).toEqual({ current: 42 });
+  });
+
+  it('works with undefined initial value', () => {
+    let ref: any;
+    const Comp = () => {
+      ref = useRef(undefined);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(ref.current).toBeUndefined();
+  });
+
+  it('returns the same ref object identity across re-renders', () => {
+    const refs: any[] = [];
+    let dispatch: any;
+    const Comp = () => {
+      const [, set] = useState(0);
+      dispatch = set;
+      refs.push(useRef('initial'));
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(runtime, () => dispatch(1));
+    expect(refs.length).toBe(2);
+    expect(refs[0]).toBe(refs[1]);
+  });
+
+  it('mutations to .current persist across re-renders', () => {
+    let ref: any;
+    let dispatch: any;
+    const Comp = () => {
+      const [, set] = useState(0);
+      dispatch = set;
+      ref = useRef('initial');
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    ref.current = 'mutated';
+    withSyncRerender(runtime, () => dispatch(1));
+    expect(ref.current).toBe('mutated');
+  });
+});

--- a/src/test/hooks/createUseRerender.test.ts
+++ b/src/test/hooks/createUseRerender.test.ts
@@ -1,0 +1,68 @@
+import { createElement, createRenderRuntime, withSyncRerender } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { domAdapter } from '../../main/dom/index.js';
+import { createRenderer } from '../../main/dom/render.js';
+import { createUseRerender } from '../../main/hooks/index.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('createUseRerender', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+  let container: HTMLDivElement;
+  let useRerender: ReturnType<typeof createUseRerender>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    useRerender = createUseRerender(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('returns a function', () => {
+    let rerender: any;
+    const Comp = () => {
+      rerender = useRerender();
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(typeof rerender).toBe('function');
+  });
+
+  it('calling the returned function triggers a re-render', () => {
+    let renderCount = 0;
+    let triggerRerender: any;
+    const Comp = () => {
+      renderCount++;
+      triggerRerender = useRerender();
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(renderCount).toBe(1);
+    withSyncRerender(runtime, triggerRerender);
+    expect(renderCount).toBe(2);
+  });
+
+  it('returns the same function identity across re-renders', () => {
+    const captured: any[] = [];
+    let triggerRerender: any;
+    const Comp = () => {
+      triggerRerender = useRerender();
+      captured.push(triggerRerender);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(runtime, triggerRerender);
+    expect(captured.length).toBe(2);
+    expect(captured[0]).toBe(captured[1]);
+  });
+});

--- a/src/test/hooks/createUseState.test.ts
+++ b/src/test/hooks/createUseState.test.ts
@@ -1,0 +1,134 @@
+import { createElement, createRenderRuntime, withSyncRerender } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { domAdapter } from '../../main/dom/index.js';
+import { createRenderer } from '../../main/dom/render.js';
+import { createUseState } from '../../main/hooks/index.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('createUseState', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+  let container: HTMLDivElement;
+  let useState: ReturnType<typeof createUseState>;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    useState = createUseState(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('returns the initial state and a dispatch function', () => {
+    let state: any, dispatch: any;
+    const Comp = () => {
+      [state, dispatch] = useState(99);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(state).toBe(99);
+    expect(typeof dispatch).toBe('function');
+  });
+
+  it('accepts a factory function as the initial state', () => {
+    let state: any;
+    const Comp = () => {
+      [state] = useState(() => 'computed');
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(state).toBe('computed');
+  });
+
+  it('dispatch(value): updates state and triggers a re-render', () => {
+    let renderCount = 0;
+    let state: any, dispatch: any;
+    const Comp = () => {
+      renderCount++;
+      [state, dispatch] = useState('initial');
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(renderCount).toBe(1);
+    expect(state).toBe('initial');
+
+    withSyncRerender(runtime, () => dispatch('updated'));
+    expect(renderCount).toBe(2);
+    expect(state).toBe('updated');
+  });
+
+  it('dispatch(fn): passes previous state to the updater and sets the result', () => {
+    let state: any, dispatch: any;
+    const Comp = () => {
+      [state, dispatch] = useState(10);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(runtime, () => dispatch((prev: number) => prev + 5));
+    expect(state).toBe(15);
+  });
+
+  it('dispatch with the same primitive value (Object.is) does NOT trigger a re-render', () => {
+    let renderCount = 0;
+    let dispatch: any;
+    const Comp = () => {
+      renderCount++;
+      [, dispatch] = useState(42);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(renderCount).toBe(1);
+    withSyncRerender(runtime, () => dispatch(42));
+    expect(renderCount).toBe(1);
+  });
+
+  it('dispatch with the same object reference does NOT trigger a re-render', () => {
+    const obj = { x: 1 };
+    let renderCount = 0;
+    let dispatch: any;
+    const Comp = () => {
+      renderCount++;
+      [, dispatch] = useState(obj);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(runtime, () => dispatch(obj));
+    expect(renderCount).toBe(1);
+  });
+
+  it('state accumulates correctly across multiple dispatches', () => {
+    const states: any[] = [];
+    let dispatch: any;
+    const Comp = () => {
+      const [s, set] = useState(0);
+      states.push(s);
+      dispatch = set;
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(runtime, () => dispatch(7));
+    withSyncRerender(runtime, () => dispatch(99));
+    expect(states).toEqual([0, 7, 99]);
+  });
+
+  it('factory function is only invoked on the first render', () => {
+    const factory = vi.fn(() => 'once');
+    let dispatch: any;
+    const Comp = () => {
+      [, dispatch] = useState(factory);
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    withSyncRerender(runtime, () => dispatch('other'));
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/hooks/lifecycle.test.ts
+++ b/src/test/hooks/lifecycle.test.ts
@@ -1,0 +1,122 @@
+import { createElement, createRenderRuntime, withSyncRerender } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getLifecycleEventBus } from '../../main/core/lifecycleEventBus.js';
+import { domAdapter } from '../../main/dom/index.js';
+import { createRenderer } from '../../main/dom/render.js';
+import { createUseEffect, createUseState } from '../../main/hooks/index.js';
+
+function makeRuntime() {
+  return createRenderRuntime(domAdapter, (type: any, el: any) => type(el.props || emptyObject));
+}
+
+describe('hooks lifecycle plugin', () => {
+  let runtime: ReturnType<typeof makeRuntime>;
+  let render: ReturnType<typeof createRenderer>;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    render = createRenderer(runtime);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('throws when hooks are called in a different order than the previous render', () => {
+    // Use an isolated runtime/container so the broken state doesn't bleed into afterEach cleanup.
+    const localRuntime = makeRuntime();
+    const localRender = createRenderer(localRuntime);
+    const localUseState = createUseState(localRuntime);
+    const localContainer = document.createElement('div');
+    document.body.appendChild(localContainer);
+
+    let dispatch: any;
+    const Comp = () => {
+      const [flag, set] = localUseState(true);
+      dispatch = set;
+      if (flag) {
+        localUseState(0); // extra hook on first render only
+      }
+      return createElement('div');
+    };
+    localRender(createElement(Comp, {}), localContainer);
+
+    // The hook plugin throws "Hooks called in a different order…", which the core
+    // catches and re-wraps as "Error occurred during rendering a component".
+    expect(() => withSyncRerender(localRuntime, () => dispatch(false))).toThrow('Error occurred during rendering');
+
+    localContainer.remove();
+  });
+
+  it('unmounting a component with no hooks does not throw', () => {
+    const NoHooks = () => createElement('span');
+    render(createElement(NoHooks, {}), container);
+    expect(() => render(null, container)).not.toThrow();
+  });
+
+  it('HOST element lifecycle events do not trigger hook state processing', () => {
+    expect(() => render(createElement('div', null, createElement('span', null, 'text')), container)).not.toThrow();
+  });
+
+  it('skips hook state processing when the event element is not an FC (direct bus publish)', () => {
+    // The core only emits lifecycle events for FC elements, so publish one manually
+    // with a HOST element to exercise the isFC early-return guard (lines 66-67).
+    const bus = getLifecycleEventBus(runtime);
+    const hostEl = createElement('div');
+    expect(() => bus.publish({ type: 'mounted', element: hostEl, renderRuntime: runtime })).not.toThrow();
+  });
+
+  it('re-rendering a component with no effects does not throw (updated: no effectsHookStates)', () => {
+    const useState = createUseState(runtime);
+    let dispatch: any;
+    const Comp = () => {
+      const [, set] = useState(0);
+      dispatch = set;
+      return createElement('div');
+    };
+    render(createElement(Comp, {}), container);
+    expect(() => withSyncRerender(runtime, () => dispatch(1))).not.toThrow();
+  });
+
+  it('skips error propagation walk when the errored event arrives already handled', () => {
+    // Publish an errored event that is pre-marked as handled so the hooks plugin
+    // short-circuits after resetting hooksIndex (line 131: if (event.handled) break).
+    const bus = getLifecycleEventBus(runtime);
+    const FakeFC = () => createElement('div');
+    const fakeEl = createElement(FakeFC, {});
+    expect(() =>
+      bus.publish({
+        type: 'errored',
+        element: fakeEl,
+        error: new Error('pre-handled'),
+        handled: true,
+        renderRuntime: runtime,
+      })
+    ).not.toThrow();
+  });
+
+  it('effects from multiple components run independently', () => {
+    const useEffect = createUseEffect(runtime);
+    const calls: string[] = [];
+    const A = () => {
+      useEffect(() => {
+        calls.push('A');
+      }, []);
+      return createElement('div');
+    };
+    const B = () => {
+      useEffect(() => {
+        calls.push('B');
+      }, []);
+      return createElement('div');
+    };
+    render(createElement('div', null, createElement(A, {}), createElement(B, {})), container);
+    expect(calls).toContain('A');
+    expect(calls).toContain('B');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.js'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
Adds comprehensive test coverage for the four main plugin modules — `dom`, `hooks`, `context`, and `compat` — and improves compat module fidelity along the way.

## What's in this PR

**`src/test/dom/`** — 100% coverage across the DOM adapter, event handling, props, and render logic.

**`src/test/hooks/`** — 100% coverage for all hook factories (`useState`, `useEffect`, `useRef`, `useRerender`, `useCatch`) and the lifecycle integration.

**`src/test/context/`** — Full coverage of `createCreateContext` and `createUseContext`: default-value fallback, Provider propagation, Object.is stability guard, nested providers, and subscription-driven re-renders (verified in isolation via `memo` + `flushMicrotasks`).

**`src/test/compat/`** — Tests for the compat layer written in `.js` (no declaration file needed). Covers `core`, `hooks`, and `renderRuntime`.

**Compat improvements (`src/main/compat/`)**
- `REF_SYMBOL` — threads refs through FC props via a Symbol, invisible to `for…in` / `Object.keys`, so HOST element spreads never accidentally activate host refs
- `forwardRef` — reads from the Symbol slot; inner component receives clean props + ref as second arg
- `flushSync` — delegates to `withSyncRerender` for a true synchronous flush
- `cloneElement` — respects falsy `props.children` (e.g. `""`) instead of falling back to `element.children`
- `Suspense` — counter-based tracking replaces boolean flag; concurrent promises are handled independently
- `Component` — proper base class with real `setState`/`forceUpdate` injected by the renderer; class instance persisted across re-renders via `useRef`