### PR TITLE
feat: @simpreact/signals — signal, computed, effect

### DIFF
--- a/docs/signals/signals.md
+++ b/docs/signals/signals.md
@@ -1,0 +1,188 @@
+# Signals
+
+`@simpreact/signals` adds fine-grained reactivity to simpreact. A signal holds a value; any FC that reads it during render automatically subscribes. When the value changes, only the subscribed components re-render.
+
+## Setup
+
+The signal factory closes over a `SimpRenderRuntime` — the same one the application already owns. Pass it once at startup alongside the other runtime consumers:
+
+```ts
+import { createRenderRuntime } from '@simpreact/internal';
+import { domAdapter, createCreateRoot } from '@simpreact/dom';
+import { createSignalFactory } from '@simpreact/signals';
+
+const renderRuntime = createRenderRuntime(domAdapter, renderer);
+const createRoot = createCreateRoot(renderRuntime);
+const { signal, computed } = createSignalFactory(renderRuntime);
+```
+
+If you use `@simpreact/compat`, import its pre-created `renderRuntime` directly:
+
+```ts
+import { renderRuntime } from '@simpreact/compat/renderRuntime';
+import { createSignalFactory } from '@simpreact/signals';
+
+const { signal, computed } = createSignalFactory(renderRuntime);
+```
+
+---
+
+## `signal(initialValue)`
+
+Returns a `WritableSignal<T>`. Read and write through `.value`:
+
+```ts
+const count = signal(0);
+
+count.value;      // read
+count.value = 1;  // write
+count.value++;    // increment
+count.value += 5; // any assignment operator works
+```
+
+Signals are typically created at module scope or inside a store object — outside the component tree.
+
+### Subscribing from a component
+
+Reading `.value` inside a component's render function is all that is needed:
+
+```ts
+const count = signal(0);
+
+function Counter() {
+  return (
+    <button onClick={() => count.value++}>
+      {count.value}
+    </button>
+  );
+}
+```
+
+The component re-renders whenever `count.value` changes. Unlike hooks, signals can be read inside loops and conditionals without restriction — subscription happens at read time, not via a slot:
+
+```ts
+const activeId = signal<string | null>(null);
+
+function Tabs({ tabs }: { tabs: { id: string; label: string }[] }) {
+  return (
+    <nav>
+      {tabs.map(tab => (
+        <button
+          key={tab.id}
+          class={activeId.value === tab.id ? 'active' : ''}
+          onClick={() => { activeId.value = tab.id; }}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
+```
+
+---
+
+## `computed(fn)`
+
+Returns a `ReadonlySignal<T>` whose value is derived from other signals. It re-evaluates automatically when any signal read inside `fn` changes.
+
+```ts
+const price = signal(100);
+const qty = signal(3);
+const total = computed(() => price.value * qty.value);
+
+total.value; // 300
+price.value = 200;
+total.value; // 600
+```
+
+Computed signals can depend on other computed signals:
+
+```ts
+const discounted = computed(() => total.value * 0.9);
+```
+
+---
+
+## `effect(fn)`
+
+Runs `fn` immediately, auto-tracks every signal read inside it, and re-runs whenever any of those signals change. Returns a dispose function that stops the effect and runs the final cleanup.
+
+```ts
+import { effect } from '@simpreact/signals';
+
+const count = signal(0);
+
+const dispose = effect(() => {
+  console.log('count is', count.value);
+});
+// → logs "count is 0"
+
+count.value = 1; // → logs "count is 1"
+count.value = 2; // → logs "count is 2"
+
+dispose(); // stops the effect
+```
+
+`fn` may return a cleanup function. It runs before each re-execution and on dispose:
+
+```ts
+const dispose = effect(() => {
+  const id = setInterval(() => console.log(count.value), 1000);
+  return () => clearInterval(id);
+});
+```
+
+`effect` is a standalone export — it does not need the render runtime and does not depend on the factory:
+
+```ts
+import { createSignalFactory, effect } from '@simpreact/signals';
+```
+
+---
+
+## Caveats
+
+**One runtime per signal factory.** All signals from a factory share a single runtime. If your app has multiple independent roots with separate runtimes, create a separate factory for each:
+
+```ts
+const signals1 = createSignalFactory(runtime1);
+const signals2 = createSignalFactory(runtime2);
+```
+
+Signals from `signals1` will not trigger re-renders in components rendered under `runtime2`, and vice versa.
+
+**Reads outside render do not subscribe.** Reading `.value` in an event handler, a `useEffect` callback, or any context outside a component's active render phase reads the value without subscribing:
+
+```ts
+function handleClick() {
+  console.log(count.value); // reads value, no subscription created
+}
+```
+
+**`Object.is` equality.** Assigning the same value does nothing — no re-render, no computed re-evaluation. Mutating an object in place and re-assigning the same reference will not trigger updates:
+
+```ts
+const state = signal({ count: 0 });
+
+// Does NOT trigger an update — same reference:
+state.value.count++;
+state.value = state.value;
+
+// Does trigger an update — new reference:
+state.value = { ...state.value, count: state.value.count + 1 };
+```
+
+**Computed deps are tracked per evaluation.** If `fn` reads different signals on different runs (e.g. behind a conditional), the dependency set updates accordingly. A signal that is no longer read will stop triggering recomputation:
+
+```ts
+const toggle = signal(true);
+const a = signal(1);
+const b = signal(2);
+
+const value = computed(() => toggle.value ? a.value : b.value);
+// Currently depends on: toggle, a
+
+toggle.value = false;
+// Now depends on: toggle, b — no longer depends on a
+```

--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
     "./shared": {
       "import": "./shared/index.js",
       "types": "./shared/index.d.ts"
+    },
+    "./signals": {
+      "import": "./signals/index.js",
+      "types": "./signals/index.d.ts"
     }
   },
   "bugs": {

--- a/src/main/compat/index.js
+++ b/src/main/compat/index.js
@@ -8,7 +8,7 @@ export * from './context.js';
 export * from './core.js';
 export * from './dom.js';
 export * from './hooks.js';
-export { jsx, jsxs, jsxDEV } from './jsx-runtime.js';
+export { jsx, jsxDEV, jsxs } from './jsx-runtime.js';
 export * from './renderRuntime.js';
 
 export default {

--- a/src/main/hooks/index.ts
+++ b/src/main/hooks/index.ts
@@ -37,6 +37,7 @@ interface HooksSpecificStore {
 }
 
 const hooksSpecificStoreByElement = new WeakMap<SimpElement, HooksSpecificStore>();
+// TODO: delete it
 const currentFCByRuntime = new WeakMap<SimpRenderRuntime, SimpElement | null>();
 
 function getHooksSpecificStore(element: SimpElement): HooksSpecificStore {

--- a/src/main/signals/computed.ts
+++ b/src/main/signals/computed.ts
@@ -1,0 +1,38 @@
+import type { SimpRenderRuntime } from '@simpreact/internal';
+import { collectDeps, Signal } from './signal.js';
+
+export class ComputedSignal<T> extends Signal<T> {
+  readonly #fn: () => T;
+  readonly #deps = new Map<Signal<unknown>, () => void>();
+
+  constructor(fn: () => T, runtime: SimpRenderRuntime) {
+    const [initialValue, initialDeps] = collectDeps(fn);
+    super(initialValue, runtime);
+    this.#fn = fn;
+    for (const dep of initialDeps) {
+      this.#subscribeToDep(dep);
+    }
+  }
+
+  #subscribeToDep(dep: Signal<unknown>): void {
+    if (!this.#deps.has(dep)) {
+      const unlisten = dep._listen(() => this.#recompute());
+      this.#deps.set(dep, unlisten);
+    }
+  }
+
+  #recompute(): void {
+    for (const unlisten of this.#deps.values()) {
+      unlisten();
+    }
+    this.#deps.clear();
+
+    const [next, newDeps] = collectDeps(this.#fn);
+
+    for (const dep of newDeps) {
+      this.#subscribeToDep(dep);
+    }
+
+    this.value = next;
+  }
+}

--- a/src/main/signals/effect.ts
+++ b/src/main/signals/effect.ts
@@ -1,0 +1,56 @@
+import { collectDeps, type Signal } from './signal.js';
+
+class Effect {
+  readonly #fn: () => void | (() => void);
+  readonly #deps = new Map<Signal<unknown>, () => void>();
+  #cleanup: (() => void) | void = undefined;
+  #disposed = false;
+
+  constructor(fn: () => void | (() => void)) {
+    this.#fn = fn;
+    this.#run();
+  }
+
+  #run(): void {
+    if (typeof this.#cleanup === 'function') {
+      this.#cleanup();
+    }
+
+    for (const unlisten of this.#deps.values()) {
+      unlisten();
+    }
+    this.#deps.clear();
+
+    const [cleanup, newDeps] = collectDeps(this.#fn);
+    this.#cleanup = cleanup;
+
+    for (const dep of newDeps) {
+      this.#deps.set(
+        dep,
+        dep._listen(() => {
+          if (!this.#disposed) {
+            this.#run();
+          }
+        })
+      );
+    }
+  }
+
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    if (typeof this.#cleanup === 'function') {
+      this.#cleanup();
+    }
+    this.#cleanup = undefined;
+    for (const unlisten of this.#deps.values()) {
+      unlisten();
+    }
+    this.#deps.clear();
+  }
+}
+
+export function effect(fn: () => void | (() => void)): () => void {
+  const e = new Effect(fn);
+  return () => e.dispose();
+}

--- a/src/main/signals/factory.ts
+++ b/src/main/signals/factory.ts
@@ -1,0 +1,23 @@
+import type { SimpRenderRuntime } from '@simpreact/internal';
+import { ComputedSignal } from './computed.js';
+import { Signal } from './signal.js';
+
+export interface ReadonlySignal<T> {
+  readonly value: T;
+}
+
+export interface WritableSignal<T> extends ReadonlySignal<T> {
+  value: T;
+}
+
+export interface SignalFactory {
+  signal<T>(initial: T): WritableSignal<T>;
+  computed<T>(fn: () => T): ReadonlySignal<T>;
+}
+
+export function createSignalFactory(runtime: SimpRenderRuntime): SignalFactory {
+  return {
+    signal: <T>(initial: T): WritableSignal<T> => new Signal(initial, runtime),
+    computed: <T>(fn: () => T): ReadonlySignal<T> => new ComputedSignal(fn, runtime),
+  };
+}

--- a/src/main/signals/index.ts
+++ b/src/main/signals/index.ts
@@ -1,0 +1,3 @@
+export { effect } from './effect.js';
+export type { ReadonlySignal, SignalFactory, WritableSignal } from './factory.js';
+export { createSignalFactory } from './factory.js';

--- a/src/main/signals/signal.ts
+++ b/src/main/signals/signal.ts
@@ -1,0 +1,63 @@
+import { rerender, type SimpElement, type SimpRenderRuntime } from '@simpreact/internal';
+
+let activeDepCollector: Set<Signal<unknown>> | null = null;
+
+export function collectDeps<T>(fn: () => T): [T, Set<Signal<unknown>>] {
+  const prev = activeDepCollector;
+  const deps = new Set<Signal<unknown>>();
+  activeDepCollector = deps;
+  let result: T;
+  try {
+    result = fn();
+  } finally {
+    activeDepCollector = prev;
+  }
+  return [result!, deps];
+}
+
+export class Signal<T> {
+  #value: T;
+  #subs = new Set<SimpElement>();
+  #listeners = new Set<() => void>();
+  readonly #runtime: SimpRenderRuntime;
+
+  constructor(initial: T, runtime: SimpRenderRuntime) {
+    this.#value = initial;
+    this.#runtime = runtime;
+  }
+
+  get value(): T {
+    const element = this.#runtime.activeRenderElement;
+    if (element) {
+      this.#subs.add(element);
+    }
+    activeDepCollector?.add(this as Signal<unknown>);
+    return this.#value;
+  }
+
+  set value(next: T) {
+    if (Object.is(this.#value, next)) {
+      return;
+    }
+
+    this.#value = next;
+    for (const element of this.#subs) {
+      if (element.unmounted) {
+        this.#subs.delete(element);
+      } else {
+        rerender(element, this.#runtime);
+      }
+    }
+    // Snapshot before iterating: #recompute() unsubscribes and re-subscribes the same
+    // dep, which would add a new entry to this Set mid-iteration and loop infinitely.
+    for (const listener of [...this.#listeners]) {
+      listener();
+    }
+  }
+
+  /** @internal */
+  _listen(fn: () => void): () => void {
+    this.#listeners.add(fn);
+    return () => this.#listeners.delete(fn);
+  }
+}

--- a/src/test/signals.test.ts
+++ b/src/test/signals.test.ts
@@ -1,0 +1,248 @@
+import { createElement, createRenderRuntime, mount, withSyncRerender } from '@simpreact/internal';
+import { emptyObject } from '@simpreact/shared';
+import { createSignalFactory, effect } from '@simpreact/signals';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { testHostAdapter } from './test-host-adapter.js';
+
+const renderRuntime = createRenderRuntime(testHostAdapter, (type, element) => {
+  return type(element.props || emptyObject);
+});
+
+let parent: Element;
+
+beforeEach(() => {
+  parent = document.createElement('div');
+  renderRuntime.renderStack.length = 0;
+});
+
+const { signal, computed } = createSignalFactory(renderRuntime);
+
+describe('createSignal', () => {
+  it('returns the initial value', () => {
+    const s = signal(42);
+    expect(s.value).toBe(42);
+  });
+
+  it('updates the value on assignment', () => {
+    const s = signal('a');
+    s.value = 'b';
+    expect(s.value).toBe('b');
+  });
+
+  it('ignores assignment when value is identical', () => {
+    const obj = {};
+    const s = signal(obj);
+    const before = s.value;
+    s.value = obj;
+    expect(s.value).toBe(before);
+  });
+
+  it('rerenders a subscribed FC when the signal changes', () => {
+    const s = signal(0);
+    let renderCount = 0;
+
+    const Comp = () => {
+      renderCount++;
+      s.value;
+      return null;
+    };
+
+    mount(createElement(Comp), parent, null, null, null, renderRuntime);
+    expect(renderCount).toBe(1);
+
+    withSyncRerender(renderRuntime, () => {
+      s.value = 1;
+    });
+    expect(renderCount).toBe(2);
+  });
+
+  it('does not rerender when the same value is assigned', () => {
+    const s = signal(0);
+    let renderCount = 0;
+
+    const Comp = () => {
+      renderCount++;
+      s.value;
+      return null;
+    };
+
+    mount(createElement(Comp), parent, null, null, null, renderRuntime);
+    expect(renderCount).toBe(1);
+
+    withSyncRerender(renderRuntime, () => {
+      s.value = 0;
+    });
+    expect(renderCount).toBe(1);
+  });
+
+  it('prunes unmounted elements lazily on next assignment', () => {
+    const s = signal(0);
+    let renderCount = 0;
+
+    const Comp = () => {
+      renderCount++;
+      s.value;
+      return null;
+    };
+
+    mount(createElement(Comp), parent, null, null, null, renderRuntime);
+    expect(renderCount).toBe(1);
+
+    const el = createElement(Comp);
+    mount(el, parent, null, null, null, renderRuntime);
+    el.unmounted = true;
+
+    expect(() => {
+      s.value = 1;
+    }).not.toThrow();
+  });
+});
+
+describe('createComputed', () => {
+  it('derives the initial value', () => {
+    const s = signal(3);
+    const doubled = computed(() => s.value * 2);
+    expect(doubled.value).toBe(6);
+  });
+
+  it('updates when a dep signal changes', () => {
+    const s = signal(1);
+    const doubled = computed(() => s.value * 2);
+    s.value = 5;
+    expect(doubled.value).toBe(10);
+  });
+
+  it('composes multiple dep signals', () => {
+    const a = signal(2);
+    const b = signal(3);
+    const sum = computed(() => a.value + b.value);
+    expect(sum.value).toBe(5);
+    a.value = 10;
+    expect(sum.value).toBe(13);
+    b.value = 7;
+    expect(sum.value).toBe(17);
+  });
+
+  it('chains computed signals', () => {
+    const s = signal(2);
+    const doubled = computed(() => s.value * 2);
+    const quadrupled = computed(() => doubled.value * 2);
+    expect(quadrupled.value).toBe(8);
+    s.value = 3;
+    expect(quadrupled.value).toBe(12);
+  });
+
+  it('rerenders a subscribed FC when a computed changes', () => {
+    const s = signal(1);
+    const doubled = computed(() => s.value * 2);
+    let renderCount = 0;
+
+    const Comp = () => {
+      renderCount++;
+      doubled.value;
+      return null;
+    };
+
+    mount(createElement(Comp), parent, null, null, null, renderRuntime);
+    expect(renderCount).toBe(1);
+
+    withSyncRerender(renderRuntime, () => {
+      s.value = 5;
+    });
+    expect(renderCount).toBe(2);
+  });
+});
+
+describe('effect', () => {
+  it('runs immediately', () => {
+    const s = signal(1);
+    let calls = 0;
+
+    const dispose = effect(() => {
+      s.value;
+      calls++;
+    });
+
+    expect(calls).toBe(1);
+    dispose();
+  });
+
+  it('re-runs when a dep changes', () => {
+    const s = signal(0);
+    const log: number[] = [];
+
+    const dispose = effect(() => {
+      log.push(s.value);
+    });
+
+    s.value = 1;
+    s.value = 2;
+    expect(log).toEqual([0, 1, 2]);
+    dispose();
+  });
+
+  it('stops re-running after dispose', () => {
+    const s = signal(0);
+    let calls = 0;
+
+    const dispose = effect(() => {
+      s.value;
+      calls++;
+    });
+    dispose();
+    s.value = 1;
+
+    expect(calls).toBe(1);
+  });
+
+  it('calls cleanup before each re-run', () => {
+    const s = signal(0);
+    const log: string[] = [];
+
+    const dispose = effect(() => {
+      const v = s.value;
+      log.push(`run:${v}`);
+      return () => log.push(`cleanup:${v}`);
+    });
+
+    s.value = 1;
+    s.value = 2;
+    expect(log).toEqual(['run:0', 'cleanup:0', 'run:1', 'cleanup:1', 'run:2']);
+    dispose();
+  });
+
+  it('calls cleanup on dispose', () => {
+    const s = signal(0);
+    let cleaned = false;
+
+    const dispose = effect(() => {
+      s.value;
+      return () => {
+        cleaned = true;
+      };
+    });
+
+    expect(cleaned).toBe(false);
+    dispose();
+    expect(cleaned).toBe(true);
+  });
+
+  it('tracks deps conditionally', () => {
+    const toggle = signal(true);
+    const a = signal('a');
+    const b = signal('b');
+    const log: string[] = [];
+
+    const dispose = effect(() => {
+      log.push(toggle.value ? a.value : b.value);
+    });
+
+    a.value = 'A'; // tracked
+    toggle.value = false;
+    a.value = 'A2'; // no longer tracked
+    b.value = 'B'; // now tracked
+
+    expect(log).toEqual(['a', 'A', 'b', 'B']);
+    dispose();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
       "@simpreact/dom": ["./src/main/dom/index.js"],
       "@simpreact/hooks": ["./src/main/hooks/index.js"],
       "@simpreact/jsx-runtime": ["./src/main/jsx-runtime/index.js"],
-      "@simpreact/shared": ["./src/main/shared/index.js"]
+      "@simpreact/shared": ["./src/main/shared/index.js"],
+      "@simpreact/signals": ["./src/main/signals/index.js"]
     }
   },
   "include": ["./src/**/*"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       '@simpreact/hooks': path.resolve(process.cwd(), './src/main/hooks/index.js'),
       '@simpreact/jsx-runtime': path.resolve(process.cwd(), './src/main/hooks/index.js'),
       '@simpreact/shared': path.resolve(process.cwd(), './src/main/shared/index.js'),
+      '@simpreact/signals': path.resolve(process.cwd(), './src/main/signals/index.js'),
     },
   },
   test: {


### PR DESCRIPTION
Closes #10

## Summary

- `createSignalFactory(runtime)` — factory that closes over a `SimpRenderRuntime`; signals read `runtime.activeRenderElement` for FC auto-subscription with zero changes to core
- `signal(initial)` — `WritableSignal<T>` with a `.value` getter/setter; any FC that reads `.value` during render subscribes automatically and rerenders on change
- `computed(fn)` — `ReadonlySignal<T>` that derives its value from other signals via automatic dep tracking; recomputes when any dep changes
- `effect(fn)` — standalone reactive side-effect; runs immediately, auto-tracks deps, re-runs on change, accepts optional cleanup function, returns `dispose()`
- `docs/signals/signals.md` — usage guide with caveats

## Design notes

Signals are a peer of `createCreateRoot` and `createRenderer` — just another consumer of a user-owned runtime. No modifications to core mounting/patching code.

Key implementation detail: `Signal.set()` snapshots `[...#listeners]` before iterating to prevent an infinite loop — `ComputedSignal.#recompute()` deletes its old listener and re-adds a new one to the same `Set` during execution, which JavaScript's `Set` iterator would otherwise visit on the next turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)